### PR TITLE
use dedicated exec group for link actions

### DIFF
--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -55,6 +55,7 @@ bzl_library(
         "//go/private:common",
         "//go/private:mode",
         "//go/private:rpath",
+        "//go/private/rules:execgroup",
         "@bazel_skylib//lib:collections",
     ],
 )

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -33,6 +33,10 @@ load(
     "@bazel_skylib//lib:collections.bzl",
     "collections",
 )
+load(
+    "//go/private/rules:execgroup.bzl",
+    "LINK_EXEC_GROUP",
+)
 
 def _format_archive(d):
     return "{}={}={}".format(d.label, d.importmap, d.file.path)
@@ -206,6 +210,7 @@ def emit_link(
         inputs = inputs,
         outputs = [executable],
         mnemonic = "GoLink",
+        exec_group = LINK_EXEC_GROUP,
         executable = go.toolchain._builder,
         arguments = [builder_args, "--", tool_args],
         env = go.env,

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -42,6 +42,7 @@ bzl_library(
         "//go/private:mode",
         "//go/private:providers",
         "//go/private:rpath",
+        "//go/private/rules:execgroup",
         "//go/private/rules:transition",
     ],
 )
@@ -54,6 +55,14 @@ bzl_library(
         "//go/private:common",
         "//go/private:mode",
     ],  # keep
+)
+
+bzl_library(
+    name = "execgroup",
+    srcs = ["execgroup.bzl"],
+    visibility = [
+        "//go:__subpackages__",
+    ],
 )
 
 bzl_library(
@@ -84,6 +93,7 @@ bzl_library(
     deps = [
         "//go/private:context",
         "//go/private:providers",
+        "//go/private/rules:execgroup",
         "//go/private/rules:transition",
     ],
 )
@@ -131,6 +141,7 @@ bzl_library(
         "//go/private:mode",
         "//go/private:providers",
         "//go/private/rules:binary",
+        "//go/private/rules:execgroup",
         "//go/private/rules:transition",
         "@bazel_skylib//lib:structs",
     ],

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -36,6 +36,10 @@ load(
     "go_transition",
 )
 load(
+    "//go/private/rules:execgroup.bzl",
+    "RULES_GO_EXEC_GROUPS",
+)
+load(
     "//go/private:mode.bzl",
     "LINKMODES",
     "LINKMODES_EXECUTABLE",
@@ -414,6 +418,7 @@ _go_binary_kwargs = {
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
+    "exec_groups": RULES_GO_EXEC_GROUPS,
     "toolchains": [GO_TOOLCHAIN],
     "doc": """This builds an executable from a set of source files,
     which must all be in the `main` package. You can run the binary with

--- a/go/private/rules/execgroup.bzl
+++ b/go/private/rules/execgroup.bzl
@@ -1,0 +1,5 @@
+LINK_EXEC_GROUP = "GoLink"
+
+RULES_GO_EXEC_GROUPS = {
+    LINK_EXEC_GROUP: exec_group(),
+}

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -28,6 +28,10 @@ load(
     "get_archive",
 )
 load(
+    "//go/private/rules:execgroup.bzl",
+    "RULES_GO_EXEC_GROUPS",
+)
+load(
     "//go/private/rules:transition.bzl",
     "go_tool_transition",
 )
@@ -106,6 +110,7 @@ _nogo = rule(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
+    exec_groups = RULES_GO_EXEC_GROUPS,
     toolchains = [GO_TOOLCHAIN],
     cfg = go_tool_transition,
 )

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -45,6 +45,10 @@ load(
     "go_transition",
 )
 load(
+    "//go/private/rules:execgroup.bzl",
+    "RULES_GO_EXEC_GROUPS",
+)
+load(
     "//go/private:mode.bzl",
     "LINKMODES",
 )
@@ -443,6 +447,7 @@ _go_test_kwargs = {
     },
     "executable": True,
     "test": True,
+    "exec_groups": RULES_GO_EXEC_GROUPS,
     "toolchains": [GO_TOOLCHAIN],
     "doc": """This builds a set of tests that can be run with `bazel test`.<br><br>
     To run all tests in the workspace, and print output on failure (the


### PR DESCRIPTION
When remote execution is used, a user may want to use different
exec properties for different actions under the same target.

For example:

A go_test could include 3 different actions:
- GoCompilePkg
- GoLink
- GoTest

If users wish to use a special exec_properties for GoLink actions,
after this PR, they could do so with:

```python
go_test(
  ...
  exec_properties = {
    # Default
    "container-image": "docker://alpine",
    "EstimatedMemory": "500MB",

    # Only applied to GoLink exec_group
    "GoLink.container-image": "docker://ubuntu",
    "GoLink.EstimatedMemory": "2GB",
  }
  ...
)
```

Reference: https://bazel.build/extending/exec-groups

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
