### PR TITLE
Make `go_bazel_test` pass with Bzlmod enabled

### DIFF
--- a/go/tools/bazel_testing/def.bzl
+++ b/go/tools/bazel_testing/def.bzl
@@ -43,6 +43,9 @@ def go_bazel_test(rule_files = None, **kwargs):
                       ["-end_files"] +
                       kwargs["args"])
 
+    kwargs.setdefault("env", {})
+    kwargs["env"]["BZLMOD_ENABLED"] = str(str(Label("//:foo")).startswith("@@"))
+
     # Set rundir to the workspace root directory to ensure relative paths
     # are interpreted correctly.
     kwargs.setdefault("rundir", ".")


### PR DESCRIPTION
This is a quick fix for the test runner only, the tests themselves still rely on WORKSPACE (via local_repository). The rules_go repo is also hardcoded, which means that other external repos likely won't work.

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
> Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
