### PR TITLE
try and add an xdef to mimic what go toolset does for testing.Testing…

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -150,7 +150,8 @@ def _go_test_impl(ctx):
     # before user code. See comment above the init function
     # in bzltestutil/init.go.
     test_gc_linkopts.extend(["-X", "+initfirst/github.com/bazelbuild/rules_go/go/tools/bzltestutil/chdir.RunDir=" + run_dir])
-
+    #post golang 1.23 testing.Testing is expected to be set for go tests
+    test_gc_linkopts.extend(["-X", "testing.Testing=1"])
     # Now compile the test binary itself
     test_library = GoLibrary(
         name = go.label.name + "~testmain",
@@ -311,7 +312,6 @@ _go_test_kwargs = {
             doc = """Map of defines to add to the go link command.
             See [Defines and stamping] for examples of how to use these.
             """,
-            "testing.testBinary" = "1",
         ),
         "linkmode": attr.string(
             default = "auto",

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -311,6 +311,7 @@ _go_test_kwargs = {
             doc = """Map of defines to add to the go link command.
             See [Defines and stamping] for examples of how to use these.
             """,
+            "testing.testBinary" = "1",
         ),
         "linkmode": attr.string(
             default = "auto",


### PR DESCRIPTION
See  https://pkg.go.dev/testing\#Testing
Go test sets an -X so that code knows if its in a UT


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**
 Feature? 

**What does this PR do? Why is it needed?**
Adds an xdef to mimic go test more precisely. 

Should we only do for go > 1.23?

**Which issues(s) does this PR fix?**

Fixes #3686

**Other notes for review**
