### PR TITLE
fix: properly expand absolute path placeholder for link calls

### DIFF
--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -57,6 +57,16 @@ go_test(
     ],
 )
 
+go_test(
+    name = "env_test",
+    size = "small",
+    srcs = [
+        "env.go",
+        "env_test.go",
+        "flags.go",
+    ],
+)
+
 filegroup(
     name = "builder_srcs",
     srcs = [

--- a/go/tools/builders/builder.go
+++ b/go/tools/builders/builder.go
@@ -32,16 +32,27 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	if len(args) == 0 {
+
+	verb := verbFromName(os.Args[0])
+	if verb == "" && len(args) == 0 {
 		log.Fatalf("usage: %s verb options...", os.Args[0])
 	}
-	verb, rest := args[0], args[1:]
+
+	var rest []string
+	if verb == "" {
+		verb, rest = args[0], args[1:]
+	} else {
+		rest = args
+	}
 
 	var action func(args []string) error
 	switch verb {
-	case "compilepkg": action = compilePkg
-	case "nogo": action = nogo
-	case "nogovalidation": action = nogoValidation
+	case "compilepkg":
+		action = compilePkg
+	case "nogo":
+		action = nogo
+	case "nogovalidation":
+		action = nogoValidation
 	case "filterbuildid":
 		action = filterBuildID
 	case "gentestmain":

--- a/go/tools/builders/cc.go
+++ b/go/tools/builders/cc.go
@@ -13,12 +13,13 @@ import (
 func cc(args []string) error {
 	cc := os.Getenv("GO_CC")
 	if cc == "" {
-		errors.New("GO_CC environment variable not set")
+		return errors.New("GO_CC environment variable not set")
 	}
 	ccroot := os.Getenv("GO_CC_ROOT")
 	if ccroot == "" {
-		errors.New("GO_CC_ROOT environment variable not set")
+		return errors.New("GO_CC_ROOT environment variable not set")
 	}
+
 	normalized := []string{cc}
 	normalized = append(normalized, args...)
 	transformArgs(normalized, cgoAbsEnvFlags, func(s string) string {
@@ -26,10 +27,10 @@ func cc(args []string) error {
 			trimmed := strings.TrimPrefix(s, cgoAbsPlaceholder)
 			abspath := filepath.Join(ccroot, trimmed)
 			if _, err := os.Stat(abspath); err == nil {
-                                // Only return the abspath if it exists, otherwise it
-                                // means that either it won't have any effect or the original
-                                // value was not a relpath (e.g. a path with a XCODE placehold from
-                                // macos cc_wrapper)
+				// Only return the abspath if it exists, otherwise it
+				// means that either it won't have any effect or the original
+				// value was not a relpath (e.g. a path with a XCODE placehold from
+				// macos cc_wrapper)
 				return abspath
 			}
 			return trimmed

--- a/go/tools/builders/env.go
+++ b/go/tools/builders/env.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strconv"
 	"strings"
@@ -160,6 +161,86 @@ func (e *env) runCommandToFile(out, err io.Writer, args []string) error {
 	cmd.Stdout = out
 	cmd.Stderr = err
 	return runAndLogCommand(cmd, e.verbose)
+}
+
+func symlinkBuilderCC() (func(), string, error) {
+	absPath, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		return nil, "", err
+	}
+
+	dirname, err := os.MkdirTemp("", "")
+	if err != nil {
+		return nil, "", err
+	}
+
+	// re-use the file extension if there is one (mostly for .exe)
+	builderPath := filepath.Join(dirname, "builder-cc"+filepath.Ext(os.Args[0]))
+
+	if err := os.Symlink(absPath, builderPath); err != nil {
+		_ = os.RemoveAll(dirname)
+		return nil, "", err
+	}
+
+	return func() { _ = os.RemoveAll(dirname) }, builderPath, nil
+}
+
+var symlinkBuilderName = regexp.MustCompile(`.*builder-(\w+)(\.exe)?$`)
+
+// verbFromName parses the builder verb from the builder name so
+// that the builder+verb can be invoked in a way that allows the verb
+// to be part of the program name, rather than requring it to be in the
+// arg list. this makes it easier to set a program like `builder cc` as
+// an environment variable in a way that is more compatible
+func verbFromName(arg0 string) string {
+	matches := symlinkBuilderName.FindAllStringSubmatch(arg0, 1)
+	if len(matches) != 1 {
+		return ""
+	}
+
+	if len(matches[0]) < 2 {
+		return ""
+	}
+
+	return matches[0][1]
+}
+
+// absCCLinker sets the target of the `-extld` to a name which `verbFromName`
+// can extract correctly, allowing go tool link to be able to use the `builder cc` wrapper
+func absCCLinker(argList []string) (func(), error) {
+	extldIndex := -1
+	for i, arg := range argList {
+		if arg == "-extld" && i+1 < len(argList) {
+			extldIndex = i + 1
+			break
+		}
+	}
+	if extldIndex < 0 {
+		// if we don't find extld just return
+		// a noop cleanup function
+		return func() {}, nil
+	}
+
+	cleanup, buildercc, err := symlinkBuilderCC()
+	if err != nil {
+		return nil, err
+	}
+
+	err = os.Setenv("GO_CC", argList[extldIndex])
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	err = os.Setenv("GO_CC_ROOT", abs("."))
+	if err != nil {
+		cleanup()
+		return nil, err
+	}
+
+	argList[extldIndex] = buildercc
+
+	return cleanup, nil
 }
 
 // absCCCompiler modifies CGO flags to workaround relative paths.

--- a/go/tools/builders/env_test.go
+++ b/go/tools/builders/env_test.go
@@ -1,0 +1,26 @@
+//go:build !windows
+
+package main
+
+import "testing"
+
+func TestVerbFromName(t *testing.T) {
+	testCases := []struct {
+		name string
+		verb string
+	}{
+		{"/a/b/c/d/builder", ""},
+		{"builder", ""},
+		{"/a/b/c/d/builder-cc", "cc"},
+		{"builder-ld", "ld"},
+		{"c:\\builder\\builder.exe", ""},
+		{"c:\\builder with spaces\\builder-cc.exe", "cc"},
+	}
+
+	for _, tc := range testCases {
+		result := verbFromName(tc.name)
+		if result != tc.verb {
+			t.Fatalf("retrieved invalid verb %q from name %q", result, tc.name)
+		}
+	}
+}

--- a/tests/core/cgo/BUILD.bazel
+++ b/tests/core/cgo/BUILD.bazel
@@ -400,6 +400,11 @@ go_test(
     cgo = True,
 )
 
+go_bazel_test(
+    name = "cgo_abs_paths_test",
+    srcs = ["cgo_abs_paths_test.go"],
+)
+
 cc_library(
     name = "cgo_link_dep",
     srcs = ["cgo_link_dep.c"],

--- a/tests/core/cgo/cgo_abs_paths_test.go
+++ b/tests/core/cgo/cgo_abs_paths_test.go
@@ -1,0 +1,82 @@
+package cgo_abs_paths_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- main.go --
+package main
+
+/*
+#include <stdio.h>
+
+void hello() {
+	printf("Hello, world!\n");
+}
+*/
+import "C"
+
+func main() {
+	C.hello()
+}
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test", "go_library")
+
+go_library(
+    name = "example_lib",
+    srcs = ["main.go"],
+	cgo = True,
+    importpath = "example.com/cmd/example",
+)
+
+go_test(
+    name = "example",
+    embed = [":example_lib"],
+	pure = "off",
+)
+`,
+		SetUp: func() error {
+			// we have to force a bazel clean because this test needs to
+			// fully execute every time so that we can actually scan the output
+			return bazel_testing.RunBazel("clean")
+		},
+	})
+}
+
+func TestCgoAbsolutePaths(t *testing.T) {
+	_, stderrBytes, err := bazel_testing.BazelOutputWithInput(nil,
+		"build",
+		"--linkopt=-Lan/imaginary/lib",
+		"--linkopt=-v",
+		"--copt=-Ian/imaginary/include",
+		"--copt=-v",
+		"-s",
+		"//:example",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := string(stderrBytes)
+
+	if strings.Contains(stderr, "__GO_BAZEL_CC_PLACEHOLDER__") {
+		t.Log(stderr)
+		t.Fatal("Found absolute path placeholder string in go linker command output")
+	}
+
+	if !strings.Contains(stderr, "-Lan/imaginary/lib") {
+		t.Log(stderr)
+		t.Fatal("Could not find --linkopt in go linker command output")
+	}
+
+	if !strings.Contains(stderr, "-Ian/imaginary/include") {
+		t.Log(stderr)
+		t.Fatal("Could not find --copt in go compiler command output")
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

PR #4009 added a mechanism that uses a sentinel value as a placeholder for paths which need to be expanded to absolutes for compile operations. These paths end up embedded in `.a` files and come back to the linker during link operations. The previous PR replaces the `CC` tool with a pointer to `builder cc` which in turn substitutes the placeholder value for actual paths. Unfortunately this wasn't done for the linker, so the linker is receiving parameters like `--sysroot=__GO_BAZEL_CC_PLACEHOLDER__external/_main~_repo_rules~ubuntu_20_04_sysroot/` which is not valid. When a sysroot is configured this means that internally the linker won't be able to find the sysroot in some cases.

In almost comically bad luck, this *only* affects the `go tool link` calls to `linkerFlagSupported` because for some reason `linkerFlagSupported` puts the `-extldflags` at the *beginning* of the linker command, while the main host link command has them at the end. So this means the linker detects all flags as unsupported but then proceeds to run the linker "correctly" which results in really confusing linker errors. In my case this resulted in the linker trying to run with `-rdynamic` incorrectly.

**Which issues(s) does this PR fix?**

Fixes #3886 

It could be reasonable to open a bug against `go tool link` describing the difference between the host link and the flag checks. I suspect it's not really intended behavior and was just sort of happenstance that things ended up that way.

I also really have no idea how to write a test for this. I'm willing to give it a shot but would really appreciate a suggestion as to where/how.
