### PR TITLE
feat: avoid cc toolchain selection (#4145)

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -43,6 +43,7 @@ stdlib(
     name = "stdlib",
     cgo_context_data = select({
         "//go/platform:internal_cgo_off": None,
+        "//go/private:is_pure": None,
         "//conditions:default": ":cgo_context_data",
     }),
     visibility = ["//visibility:public"],
@@ -72,6 +73,7 @@ go_context_data(
     name = "go_context_data",
     cgo_context_data = select({
         "//go/platform:internal_cgo_off": None,
+        "//go/private:is_pure": None,
         "//conditions:default": ":cgo_context_data",
     }),
     coverdata = "//go/tools/coverdata",
@@ -95,6 +97,7 @@ cgo_context_data_proxy(
     name = "cgo_context_data_proxy",
     actual = select({
         "//go/platform:internal_cgo_off": None,
+        "//go/private:is_pure": None,
         "//conditions:default": ":cgo_context_data",
     }),
     visibility = ["//visibility:public"],

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -215,4 +215,5 @@ config_setting(
     flag_values = {
         "//go/config:pure": "True",
     },
+    visibility = ["//:__pkg__"],
 )

--- a/go/private/BUILD.bazel
+++ b/go/private/BUILD.bazel
@@ -209,3 +209,10 @@ config_setting(
     },
     visibility = ["//:__pkg__"],
 )
+
+config_setting(
+    name = "is_pure",
+    flag_values = {
+        "//go/config:pure": "True",
+    },
+)


### PR DESCRIPTION
**What type of PR is this?**

> Feature

**What does this PR do? Why is it needed?**

//:cgo_context_data is in the dependency closure of pure go_binary targets. This PR adds a config_setting to detect when //go/config:pure is set to True and updates the places where //:cgo_context_data is selected.

**Which issues(s) does this PR fix?**

Fixes #4145 

**Other notes for review**

No breaking tests have been added, but the functionality can be seen on the pure targets in the test folder. e.g.
```
bazel cquery "somepath(//tests/core/go_binary:static_pure_bin, //:cgo_context_data)"
INFO: Analyzed 2 targets (0 packages loaded, 0 targets configured).
INFO: Found 2 targets...
INFO: Empty query results
INFO: Elapsed time: 0.097s, Critical Path: 0.00s
INFO: 0 processes.
INFO: Build completed successfully, 0 total actions
```