### PR TITLE
Fix `go_tool_binary` non-hermeticity and Go 1.19 incompatibility

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,7 +1,7 @@
 workspace(name = "io_bazel_rules_go")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_dependencies")
+load("@io_bazel_rules_go//go:deps.bzl", "go_download_sdk", "go_register_nogo", "go_register_toolchains", "go_rules_dependencies")
 
 # Required by toolchains_protoc.
 http_archive(
@@ -28,6 +28,15 @@ bazel_features_deps()
 go_rules_dependencies()
 
 go_register_toolchains(version = "1.23.1")
+
+go_download_sdk(
+    name = "rules_go_internal_compatibility_sdk",
+    version = "1.19.13",
+)
+
+go_register_nogo(
+    nogo = "@//:tools_nogo",
+)
 
 http_archive(
     name = "rules_proto",
@@ -137,7 +146,7 @@ grpc_dependencies()
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
 
-gazelle_dependencies()
+gazelle_dependencies(go_sdk = "go_sdk")
 
 go_repository(
     name = "com_github_google_go_github_v36",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -35,7 +35,7 @@ go_download_sdk(
 )
 
 go_register_nogo(
-    nogo = "@//:tools_nogo",
+    nogo = "@//internal:nogo",
 )
 
 http_archive(

--- a/go/private/nogo.bzl
+++ b/go/private/nogo.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 DEFAULT_NOGO = "@io_bazel_rules_go//:default_nogo"
-NOGO_DEFAULT_INCLUDES = ["@@//:__subpackages__"]
+NOGO_DEFAULT_INCLUDES = [str(Label("//:__subpackages__"))]
 NOGO_DEFAULT_EXCLUDES = []
 
 # repr(Label(...)) does not emit a canonical label literal.

--- a/go/runfiles/manifest.go
+++ b/go/runfiles/manifest.go
@@ -138,7 +138,8 @@ func (m *manifest) open(name string) (fs.File, error) {
 			// name refers to an actual file or dir listed in the manifest. The
 			// basename of name may not match the basename of the underlying
 			// file (e.g. in the case of a root symlink), so patch it.
-			f, err := os.Open(r)
+			var f *os.File
+			f, err = os.Open(r)
 			if err != nil {
 				return nil, err
 			}

--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -223,7 +223,7 @@ func checkPackage(analyzers []*analysis.Analyzer, packagePath string, packageFil
 		if _, ok := ignoreFilesSet[pkg.fset.Position(f.Pos()).Filename]; ok {
 			for _, act := range actions {
 				act.nolint = append(act.nolint, &Range{
-					from: pkg.fset.Position(f.FileStart),
+					from: pkg.fset.Position(f.Pos()),
 					to:   pkg.fset.Position(f.End()).Line,
 				})
 			}

--- a/go/tools/releaser/prepare.go
+++ b/go/tools/releaser/prepare.go
@@ -125,7 +125,7 @@ func runPrepare(ctx context.Context, stderr io.Writer, args []string) error {
 	branchName := "release-" + majorMinor[len("v"):]
 	if !gitBranchExists(ctx, rootDir, branchName) {
 		if !isMinorRelease {
-			return fmt.Errorf("release branch %q does not exist locally. Fetch it, set RULES_GO_VERSION, add commits, and run this command again.")
+			return fmt.Errorf("release branch %q does not exist locally. Fetch it, set RULES_GO_VERSION, add commits, and run this command again.", branchName)
 		}
 		if err := checkRulesGoVersion(ctx, rootDir, "HEAD", version); err != nil {
 			return err
@@ -247,7 +247,7 @@ func checkRulesGoVersion(ctx context.Context, dir, refName, version string) erro
 	}
 	rulesGoVersionStr := []byte(fmt.Sprintf(`RULES_GO_VERSION = "%s"`, version[len("v"):]))
 	if !bytes.Contains(data, rulesGoVersionStr) {
-		return fmt.Errorf("RULES_GO_VERSION was not set to %q in go/def.bzl. Set it, add commits, and run this command again.")
+		return fmt.Errorf("RULES_GO_VERSION was not set to %q in go/def.bzl. Set it, add commits, and run this command again.", version)
 	}
 	return nil
 }

--- a/go/tools/releaser/upgradedep.go
+++ b/go/tools/releaser/upgradedep.go
@@ -461,8 +461,8 @@ func upgradeDepDecl(ctx context.Context, gh *githubClient, workDir, name string,
 			}
 			patchName := patchLabelValue[len("//third_party:"):]
 			patchPath := filepath.Join(rootDir, "third_party", patchName)
-			prevDir := filepath.Join(workDir, name, string('a'+patchIndex))
-			patchDir := filepath.Join(workDir, name, string('a'+patchIndex+1))
+			prevDir := filepath.Join(workDir, name, fmt.Sprintf("a%d", patchIndex))
+			patchDir := filepath.Join(workDir, name, fmt.Sprintf("a%d", patchIndex+1))
 			var patchCmd []string
 			for _, c := range comments.Before {
 				words := strings.Fields(strings.TrimPrefix(c.Token, "#"))
@@ -484,7 +484,7 @@ func upgradeDepDecl(ctx context.Context, gh *githubClient, workDir, name string,
 					return err
 				}
 			}
-			patch, _ := runForOutput(ctx, filepath.Join(workDir, name), "diff", "-urN", string('a'+patchIndex), string('a'+patchIndex+1))
+			patch, _ := runForOutput(ctx, filepath.Join(workDir, name), "diff", "-urN", fmt.Sprintf("a%d", patchIndex), fmt.Sprintf("a%d", patchIndex+1))
 			patch = sanitizePatch(patch)
 			if err := os.WriteFile(patchPath, patch, 0666); err != nil {
 				return err

--- a/internal/BUILD.bazel
+++ b/internal/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//go:def.bzl", "TOOLS_NOGO", "nogo")
+
+nogo(
+    name = "nogo",
+    visibility = ["//visibility:public"],
+    deps = [
+        a
+        for a in TOOLS_NOGO
+        # Filter out shadow as it triggers on err and is very noisy.
+        if a != "@org_golang_x_tools//go/analysis/passes/shadow:go_default_library"
+    ],
+)

--- a/tests/core/compatibility/BUILD.bazel
+++ b/tests/core/compatibility/BUILD.bazel
@@ -1,0 +1,12 @@
+load("//go:def.bzl", "go_binary", "go_cross_binary")
+
+go_binary(
+    name = "hello",
+    srcs = ["hello.go"],
+)
+
+go_cross_binary(
+    name = "hello_old",
+    sdk_version = "1.19",
+    target = ":hello",
+)

--- a/tests/core/compatibility/README.md
+++ b/tests/core/compatibility/README.md
@@ -1,0 +1,5 @@
+# Compatibility
+
+## compatibility_test
+
+Verifies that a simple Go project builds with an older version of Go.

--- a/tests/core/compatibility/hello.go
+++ b/tests/core/compatibility/hello.go
@@ -1,0 +1,7 @@
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/tests/core/go_proto_library_importpath/importpath_test.go
+++ b/tests/core/go_proto_library_importpath/importpath_test.go
@@ -16,7 +16,7 @@ func Test(t *testing.T) {
 	var expected int64 = 5
 	if bar.Value.Value != expected {
 		t.Errorf(fmt.Sprintf("Not equal: \n"+
-			"expected: %s\n"+
-			"actual  : %s", expected, bar.Value.Value))
+			"expected: %d\n"+
+			"actual  : %d", expected, bar.Value.Value))
 	}
 }

--- a/tests/core/go_test/example_test.go
+++ b/tests/core/go_test/example_test.go
@@ -4,6 +4,14 @@ import "fmt"
 
 var Expected = "Expected"
 
+// Please the "tests" nogo check.
+var (
+	HelloWorld      string
+	DontTestMe      string
+	TestEmptyOutput string
+	TestQuoting     string
+)
+
 func ExampleHelloWorld() {
 	fmt.Println("Hello Example!")
 	fmt.Println("expected: " + Expected)

--- a/tests/core/go_test/filter_test_cases_test.go
+++ b/tests/core/go_test/filter_test_cases_test.go
@@ -81,7 +81,7 @@ func Test(t *testing.T) {
 			}
 			p, err := bazel_testing.BazelOutput("info", "bazel-testlogs")
 			if err != nil {
-				t.Fatal("could not find testlog root: %s", err)
+				t.Fatalf("could not find testlog root: %s", err)
 			}
 			path := filepath.Join(strings.TrimSpace(string(p)), "filter_test/test.xml")
 			b, err := ioutil.ReadFile(path)

--- a/tests/core/go_test/timeout_test.go
+++ b/tests/core/go_test/timeout_test.go
@@ -45,7 +45,7 @@ func TestTimeout(t *testing.T) {
 	if err := bazel_testing.RunBazel("test", "//:timeout_test", "--test_timeout=3", "--test_arg=-test.v"); err == nil {
 		t.Fatal("expected bazel test to fail")
 	} else if exitErr, ok := err.(*bazel_testing.StderrExitError); !ok || exitErr.Err.ExitCode() != 3 {
-		t.Fatalf("expected bazel test to fail with exit code 3", err)
+		t.Fatalf("expected bazel test to fail with exit code 3, got %v", err)
 	} else {
 		stderr = string(exitErr.Err.Stderr)
 	}

--- a/tests/core/go_test/xmlreport_test.go
+++ b/tests/core/go_test/xmlreport_test.go
@@ -142,7 +142,7 @@ func Test(t *testing.T) {
 
 			p, err := bazel_testing.BazelOutput("info", "bazel-testlogs")
 			if err != nil {
-				t.Fatal("could not find testlog root: %s", err)
+				t.Fatalf("could not find testlog root: %s", err)
 			}
 			path := filepath.Join(strings.TrimSpace(string(p)), "xml_test/test.xml")
 			b, err := ioutil.ReadFile(path)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`go_tool_binary` used to non-hermetically pick up rules_go's `go.mod` file when run unsandboxed, which resulted in it downloading a different toolchain and messing up version checks.

Also make `nogo_main.go` compatible with Go 1.19 and test with nogo (which requires fixing a bunch of violations).

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
