### PR TITLE
go_binary: Add support to set a default GODEBUG per binary

### DIFF
--- a/docs/go/core/rules.md
+++ b/docs/go/core/rules.md
@@ -127,7 +127,7 @@ Rules
 <pre>
 go_binary(<a href="#go_binary-name">name</a>, <a href="#go_binary-basename">basename</a>, <a href="#go_binary-cdeps">cdeps</a>, <a href="#go_binary-cgo">cgo</a>, <a href="#go_binary-clinkopts">clinkopts</a>, <a href="#go_binary-copts">copts</a>, <a href="#go_binary-cppopts">cppopts</a>, <a href="#go_binary-cxxopts">cxxopts</a>, <a href="#go_binary-data">data</a>, <a href="#go_binary-deps">deps</a>, <a href="#go_binary-embed">embed</a>,
           <a href="#go_binary-embedsrcs">embedsrcs</a>, <a href="#go_binary-env">env</a>, <a href="#go_binary-gc_goopts">gc_goopts</a>, <a href="#go_binary-gc_linkopts">gc_linkopts</a>, <a href="#go_binary-goarch">goarch</a>, <a href="#go_binary-goos">goos</a>, <a href="#go_binary-gotags">gotags</a>, <a href="#go_binary-importpath">importpath</a>, <a href="#go_binary-linkmode">linkmode</a>, <a href="#go_binary-msan">msan</a>,
-          <a href="#go_binary-out">out</a>, <a href="#go_binary-pgoprofile">pgoprofile</a>, <a href="#go_binary-pure">pure</a>, <a href="#go_binary-race">race</a>, <a href="#go_binary-srcs">srcs</a>, <a href="#go_binary-static">static</a>, <a href="#go_binary-x_defs">x_defs</a>)
+          <a href="#go_binary-out">out</a>, <a href="#go_binary-pgoprofile">pgoprofile</a>, <a href="#go_binary-pure">pure</a>, <a href="#go_binary-race">race</a>, <a href="#go_binary-srcs">srcs</a>, <a href="#go_binary-static">static</a>, <a href="#go_binary-x_defs">x_defs</a>, <a href="#go_binary-godebug_default">godebug_default</a>)
 </pre>
 
 This builds an executable from a set of source files,
@@ -175,6 +175,7 @@ This builds an executable from a set of source files,
 | <a id="go_binary-srcs"></a>srcs |  The list of Go source files that are compiled to create the package.                 Only <code>.go</code>, <code>.s</code>, and <code>.syso</code> files are permitted, unless the <code>cgo</code>                 attribute is set, in which case,                 <code>.c .cc .cpp .cxx .h .hh .hpp .hxx .inc .m .mm</code>                 files are also permitted. Files may be filtered at build time                 using Go [build constraints].   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional | [] |
 | <a id="go_binary-static"></a>static |  Controls whether a binary is statically linked. May be one of <code>on</code>,                 <code>off</code>, or <code>auto</code>. Not available on all platforms or in all                 modes. It's usually better to control this on the command line with                 <code>--@io_bazel_rules_go//go/config:static</code>. See [mode attributes],                 specifically [static].   | String | optional | "auto" |
 | <a id="go_binary-x_defs"></a>x_defs |  Map of defines to add to the go link command.                 See [Defines and stamping] for examples of how to use these.   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
+| <a id="go_binary-godebug_default"></a>godebug_default | Map of default GODEBUG keys and values |  <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional | {} |
 
 
 

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -208,4 +208,5 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         cgo_deps = depset(transitive = [cgo_deps] + [a.cgo_deps for a in direct]),
         cgo_exports = cgo_exports,
         runfiles = runfiles,
+        godebug_default = getattr(source, "godebug_default", None),
     )

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -140,6 +140,11 @@ def emit_link(
     ]))
     extldflags.extend(cgo_rpaths)
 
+    godebug_default = archive.godebug_default
+    if godebug_default:
+        builder_args.add("-X", "runtime.godebugDefault={}".format(
+            ",".join(["{}={}".format(k, v) for k, v in godebug_default.items()])))
+
     # Process x_defs, and record whether stamping is used.
     stamp_x_defs_volatile = False
     stamp_x_defs_stable = False

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -290,6 +290,7 @@ def _library_to_source(go, attr, library, coverage_instrumented, verify_resolver
         _merge_embed(source, e)
 
     source["deps"] = _dedup_archives(source["deps"])
+    source["godebug_default"] = getattr(attr, "godebug_default", None)
 
     x_defs = source["x_defs"]
     for k, v in getattr(attr, "x_defs", {}).items():

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -439,6 +439,9 @@ def _go_binary_kwargs(go_cc_aspects = []):
                 """,
                 default = "//go/config:empty",
             ),
+            "godebug_default": attr.string_dict(
+                doc = """Map of default GODEBUG values to add to the go link command.""",
+            ),
             "_go_context_data": attr.label(default = "//:go_context_data", cfg = go_transition),
             "_allowlist_function_transition": attr.label(
                 default = "@bazel_tools//tools/allowlists/function_transition_allowlist",

--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -241,7 +241,31 @@ go_binary(
 go_binary(
     name = "meaning2",
     srcs = [
-        "//tests/core/go_library:use_syso_srcs",
         "meaning2.go",
+        "//tests/core/go_library:use_syso_srcs",
     ],
+)
+
+go_binary(
+    name = "godebug_bin_godebug",
+    srcs = ["godebug_bin.go"],
+    godebug_default = {
+        "http2debug": "1",
+    },
+)
+
+go_binary(
+    name = "godebug_bin",
+    srcs = ["godebug_bin.go"],
+)
+
+go_test(
+    name = "godebug_test",
+    srcs = ["godebug_test.go"],
+    data = [
+        ":godebug_bin",
+        ":godebug_bin_godebug",
+    ],
+    rundir = ".",
+    deps = ["//go/tools/bazel:go_default_library"],
 )

--- a/tests/core/go_binary/README.rst
+++ b/tests/core/go_binary/README.rst
@@ -68,3 +68,7 @@ prefix
 ------
 This binary has a name that conflicts with a subdirectory. Its output file
 name should not have this conflict. Verifies `#2463`_.
+
+godebug_test
+------------
+Test that the ``godebug_default`` sets the default ``GODEBUG`` variables.

--- a/tests/core/go_binary/godebug_bin.go
+++ b/tests/core/go_binary/godebug_bin.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"internal/godebug"
+)
+
+func main() {
+	http2debug := godebug.New("http2debug")
+	fmt.Printf("%v\n", http2debug)
+}

--- a/tests/core/go_binary/godebug_test.go
+++ b/tests/core/go_binary/godebug_test.go
@@ -1,0 +1,44 @@
+package godebug
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+)
+
+func TestGodebugDefaults(t *testing.T) {
+	tests := map[string]struct {
+		binary string
+		want   string
+	}{
+		"debug": {
+			binary: "godebug_bin_godebug",
+			want:   "http2debug=1",
+		},
+		"no_debug": {
+			binary: "godebug_bin",
+			want:   "http2debug=",
+		},
+	}
+
+	for testName, tc := range tests {
+		t.Run(testName, func(t *testing.T) {
+			bin, ok := bazel.FindBinary("tests/core/go_binary", tc.binary)
+			if !ok {
+				t.Fatalf("could not find %v binary", tc.binary)
+			}
+
+			out, err := exec.Command(bin).Output()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			got := strings.TrimSpace(string(out))
+			if got != tc.want {
+				t.Errorf("got:%v\nwant:%s\n", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Go supports setting default GODEBUG values in the go.mod file or per directive in the main package at the right location. This currently does not work with rules_go/gazelle.

Introduce an explicit godebug_default attribute on go_binary so that gazelle can easily manage it.

Supports bazel-contrib/bazel-gazelle!1945

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Uncomment one line below and remove others.
>
> Bug fix
Feature
> Documentation
> Other

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
