### PR TITLE
prepare rules_go release 0.51.0-rc1

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -125,7 +125,7 @@ TOOLS_NOGO = [str(Label(l)) for l in _TOOLS_NOGO]
 
 # Current version or next version to be tagged. Gazelle and other tools may
 # check this to determine compatibility.
-RULES_GO_VERSION = "0.50.1"
+RULES_GO_VERSION = "0.51.0-rc1"
 
 go_context = _go_context
 gomock = _gomock


### PR DESCRIPTION
This PR prepare the `rc1` for the new rules go version