### PR TITLE
fix(go/tools/releaser) allow prereleases

### DIFF
--- a/go/tools/releaser/prepare.go
+++ b/go/tools/releaser/prepare.go
@@ -91,7 +91,7 @@ func runPrepare(ctx context.Context, stderr io.Writer, args []string) error {
 	if version == "" {
 		return usageErrorf(&prepareCmd, "-version must be set")
 	}
-	if semver.Canonical(version) != version || semver.Prerelease(version) != "" || semver.Build(version) != "" {
+	if semver.Canonical(version) != version || semver.Build(version) != "" {
 		return usageErrorf(&prepareCmd, "-version must be a canonical version, like v1.2.3")
 	}
 


### PR DESCRIPTION
We need to allow pre-releases in order to release the `rc1` of version `0.51`