### PR TITLE
Use rules_shell's sh_binary and sh_test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,7 @@ bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "rules_proto", version = "6.0.0")
 bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobuf")
+bazel_dep(name = "rules_shell", version = "0.3.0")
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
 go_sdk.download(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -253,7 +253,9 @@ http_archive(
 )
 
 load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
 rules_shell_dependencies()
+
 rules_shell_toolchains()
 
 load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -245,6 +245,17 @@ load(
 
 apple_support_dependencies()
 
+http_archive(
+    name = "rules_shell",
+    sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+    strip_prefix = "rules_shell-0.3.0",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+)
+
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+rules_shell_dependencies()
+rules_shell_toolchains()
+
 load("@googleapis//:repository_rules.bzl", "switched_rules_by_language")
 
 switched_rules_by_language(

--- a/docs/doc_helpers.bzl
+++ b/docs/doc_helpers.bzl
@@ -15,6 +15,7 @@
 load("@bazel_skylib//rules:diff_test.bzl", "diff_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
 load("@io_bazel_stardoc//stardoc:stardoc.bzl", "stardoc")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
 def stardoc_with_diff_test(
         bzl_library_target,
@@ -91,7 +92,7 @@ def update_docs(
         content = content,
     )
 
-    native.sh_binary(
+    sh_binary(
         name = name,
         srcs = [update_script],
         data = data,

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -300,6 +300,14 @@ def go_rules_dependencies(force = False):
         name = "io_bazel_rules_go_bazel_features",
     )
 
+    wrapper(
+      http_archive,
+      name = "rules_shell",
+      sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+      strip_prefix = "rules_shell-0.3.0",
+      url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+    )
+
 def _maybe(repo_rule, name, **kwargs):
     if name not in native.existing_rules():
         repo_rule(name = name, **kwargs)

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -301,11 +301,11 @@ def go_rules_dependencies(force = False):
     )
 
     wrapper(
-      http_archive,
-      name = "rules_shell",
-      sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
-      strip_prefix = "rules_shell-0.3.0",
-      url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+        http_archive,
+        name = "rules_shell",
+        sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+        strip_prefix = "rules_shell-0.3.0",
+        url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
     )
 
 def _maybe(repo_rule, name, **kwargs):

--- a/go/private/tools/files_equal_test.bzl
+++ b/go/private/tools/files_equal_test.bzl
@@ -12,9 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 """Tests that two files contain the same data."""
+
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 def files_equal_test(name, golden, actual, error_message = None, **kwargs):
     # This genrule creates a Bash script: the source of the actual test.

--- a/go/private/tools/files_equal_test.bzl
+++ b/go/private/tools/files_equal_test.bzl
@@ -12,6 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 
 """Tests that two files contain the same data."""
 
@@ -105,7 +106,7 @@ fi
 eof""",
     )
 
-    native.sh_test(
+    sh_test(
         name = name,
         srcs = [name + "-src.sh"],
         data = [

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -542,6 +542,20 @@ type workspaceTemplateInfo struct {
 }
 
 var defaultWorkspaceTpl = template.Must(template.New("").Parse(`
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+http_archive(
+    name = "rules_shell",
+    sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
+    strip_prefix = "rules_shell-0.3.0",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
+)
+
+load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
+
+rules_shell_dependencies()
+
+rules_shell_toolchains()
+
 {{range .WorkspaceNames}}
 local_repository(
     name = "{{.}}",

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -542,20 +542,6 @@ type workspaceTemplateInfo struct {
 }
 
 var defaultWorkspaceTpl = template.Must(template.New("").Parse(`
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-http_archive(
-    name = "rules_shell",
-    sha256 = "d8cd4a3a91fc1dc68d4c7d6b655f09def109f7186437e3f50a9b60ab436a0c53",
-    strip_prefix = "rules_shell-0.3.0",
-    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.3.0/rules_shell-v0.3.0.tar.gz",
-)
-
-load("@rules_shell//shell:repositories.bzl", "rules_shell_dependencies", "rules_shell_toolchains")
-
-rules_shell_dependencies()
-
-rules_shell_toolchains()
-
 {{range .WorkspaceNames}}
 local_repository(
     name = "{{.}}",


### PR DESCRIPTION
Bazel 8 deletes all native shell rules. In order for other rule repositories (i.e. rules_android) to use rules_go, the references to native sh_* must be converted to rules_shell's respective versions.

Unblocks https://github.com/bazelbuild/rules_android/issues/278

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Adds rules_shell dep and properly loads sh_binary/test where applicable.

**Which issues(s) does this PR fix?**

Without this PR, rule repositories cannot depend upon rules_go with Bazel 8.

Fixes #4181.

**Other notes for review**
