### PR TITLE
Update BCR metadata

### DIFF
--- a/.bcr/metadata.template.json
+++ b/.bcr/metadata.template.json
@@ -18,7 +18,7 @@
     }
   ],
   "repository": [
-    "github:bazelbuild/rules_go"
+    "github:bazel-contrib/rules_go"
   ],
   "versions": [],
   "yanked_versions": {}


### PR DESCRIPTION
Reflect the move to the `bazel-contrib` org.