### PR TITLE
Support Go 1.24's wasip1 reactors

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -43,7 +43,8 @@ def emit_binary(
     archive = go.archive(go, source)
     if not executable:
         if go.mode.linkmode == LINKMODE_C_SHARED:
-            name = "lib" + name  # shared libraries need a "lib" prefix in their name
+            if go.mode.goos != "wasip1":
+                name = "lib" + name  # shared libraries need a "lib" prefix in their name
             extension = goos_to_shared_extension(go.mode.goos)
         elif go.mode.linkmode == LINKMODE_C_ARCHIVE:
             extension = ARCHIVE_EXTENSION

--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -101,12 +101,13 @@ def goos_to_extension(goos):
 
 ARCHIVE_EXTENSION = ".a"
 
-SHARED_LIB_EXTENSIONS = [".dll", ".dylib", ".so"]
+SHARED_LIB_EXTENSIONS = [".dll", ".dylib", ".so", ".wasm"]
 
 def goos_to_shared_extension(goos):
     return {
         "windows": ".dll",
         "darwin": ".dylib",
+        "wasip1": ".wasm",
     }.get(goos, ".so")
 
 def has_shared_lib_extension(path):

--- a/go/private/mode.bzl
+++ b/go/private/mode.bzl
@@ -65,7 +65,7 @@ def validate_mode(mode):
             fail("race instrumentation can't be enabled when cgo is disabled. Check that pure is not set to \"off\" and a C/C++ toolchain is configured.")
         if mode.msan:
             fail("msan instrumentation can't be enabled when cgo is disabled. Check that pure is not set to \"off\" and a C/C++ toolchain is configured.")
-        if mode.linkmode in LINKMODES_REQUIRING_EXTERNAL_LINKING:
+        if mode.linkmode in LINKMODES_REQUIRING_EXTERNAL_LINKING and mode.goos != "wasip1":
             fail(("linkmode '{}' can't be used when cgo is disabled. Check that pure is not set to \"off\" and that a C/C++ toolchain is configured for " +
                   "your current platform. If you defined a custom platform, make sure that it has the @io_bazel_rules_go//go/toolchain:cgo_on constraint value.").format(mode.linkmode))
 


### PR DESCRIPTION
**What type of PR is this?**

 Bug fix

**What does this PR do? Why is it needed?**

[Go 1.24](https://go.dev/doc/go1.24#wasm) added support for `GOOS=wasip1 GOARCH=wasm go build -buildmode=c-shared`; however, the rules_go starlark code contained validation against this.

* Fixes validation error in newly supported go 1.24 wasip1-wasm tuple with -buildmode=c-shared.
* Removes lib prefix for wasip1 -buildmode=c-shared
* Adds `.wasm` suffix for wasi reactors built with `-buildmode=c-shared`

**Which issues(s) does this PR fix?**

Fixes #4200

**Other notes for review**

It looks like this could use a test (as simple as adding a new go file under `tests/core/c_linkmodes/`); however, the support for features added in this PR requires Go 1.24, which is not out yet. Updating `go_register_toolchains(version = "1.24rc1")` does allow it to build, but then `nogo` fails due to lack of support in some of the linters for go 1.24.
