### PR TITLE
fix: Make context.mode always be GoConfigInfo

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -514,7 +514,7 @@ def go_context(
             if getattr(ctx.attr, "pure", None) == "off":
                 fail("{} has pure explicitly set to off, but no C++ toolchain could be found for its platform".format(ctx.label))
             mode_kwargs["pure"] = True
-        mode = struct(**mode_kwargs)
+        mode = GoConfigInfo(**mode_kwargs)
         validate_mode(mode)
 
     if stdlib:

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -503,7 +503,7 @@ def go_context(
 
     if goos == "auto" and goarch == "auto" and cgo_context_info:
         # Fast-path to reuse the GoConfigInfo as-is
-        mode = go_config_info
+        mode = go_config_info or default_go_config_info
     else:
         if go_config_info == None:
             go_config_info = default_go_config_info

--- a/tests/core/cross/BUILD.bazel
+++ b/tests/core/cross/BUILD.bazel
@@ -7,6 +7,16 @@ test_suite(
 )
 
 go_binary(
+    name = "non_pure_cross",
+    srcs = ["main.go"],
+    goarch = "amd64",
+    goos = "darwin",
+    pure = "off",
+    target_compatible_with = ["@platforms//os:macos"],
+    deps = [":platform_lib"],
+)
+
+go_binary(
     name = "windows_cross",
     srcs = ["main.go"],
     goarch = "amd64",


### PR DESCRIPTION

**What type of PR is this?**
Bug fix 

**What does this PR do? Why is it needed?**
Providers and structs with the same fields don't compare equal

**Which issues(s) does this PR fix?**
Fixes #4197

I wasn't able to figure out a repro in rules_go, it seems like it may rely on some transitions? Not sure we should block landing on this, it seems like this should be the right fix