### PR TITLE
chore: remove Travis-specific install docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -19,7 +19,6 @@ Go rules for Bazel_
 .. _Proto dependencies: go/dependencies.rst#proto-dependencies
 .. _Proto rules: proto/core.rst
 .. _Protocol buffers: proto/core.rst
-.. _Running Bazel Tests on Travis CI: https://kev.inburke.com/kevin/bazel-tests-on-travis-ci/
 .. _Toolchains: go/toolchains.rst
 .. _Using rules_go on Windows: windows.rst
 .. _bazel-go-discuss: https://groups.google.com/forum/#!forum/bazel-go-discuss
@@ -29,7 +28,6 @@ Go rules for Bazel_
 .. _gazelle: https://github.com/bazelbuild/bazel-gazelle
 .. _github.com/bazelbuild/bazel-gazelle: https://github.com/bazelbuild/bazel-gazelle
 .. _github.com/bazelbuild/rules_go/go/tools/bazel: https://pkg.go.dev/github.com/bazelbuild/rules_go/go/tools/bazel?tab=doc
-.. _korfuri/bazel-travis Use Bazel with Travis CI: https://github.com/korfuri/bazel-travis
 .. _nogo build-time static analysis: go/nogo.rst
 .. _nogo: go/nogo.rst
 .. _rules_go and Gazelle roadmap: https://github.com/bazelbuild/rules_go/wiki/Roadmap
@@ -625,7 +623,6 @@ FAQ
 **Dependencies and testing**
 
 * `How do I use different versions of dependencies?`_
-* `How do I run Bazel on Travis CI?`_
 * `How do I test a beta version of the Go SDK?`_
 
 Can I still use the go command?
@@ -853,52 +850,6 @@ How do I use different versions of dependencies?
 
 See `Overriding dependencies`_ for instructions on overriding repositories
 declared in `go_rules_dependencies`_.
-
-
-How do I run Bazel on Travis CI?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-References:
-
-* `Running Bazel Tests on Travis CI`_ by Kevin Burke
-* `korfuri/bazel-travis Use Bazel with Travis CI`_
-
-In order to run Bazel tests on Travis CI, you'll need to install Bazel in the
-``before_install`` script. See our configuration file linked above.
-
-You'll want to run Bazel with a number of flags to prevent it from consuming
-a huge amount of memory in the test environment.
-
-* ``--host_jvm_args=-Xmx500m --host_jvm_args=-Xms500m``: Set the maximum and
-  initial JVM heap size. Keeping the same means the JVM won't spend time
-  growing the heap. The choice of heap size is somewhat arbitrary; other
-  configuration files recommend limits as high as 2500m. Higher values mean
-  a faster build, but higher risk of OOM kill.
-* ``--bazelrc=.test-bazelrc``: Use a Bazel configuration file specific to
-  Travis CI. You can put most of the remaining options in here.
-* ``build --spawn_strategy=standalone --genrule_strategy=standalone``: Disable
-  sandboxing for the build. Sandboxing may fail inside of Travis's containers
-  because the ``mount`` system call is not permitted.
-* ``test --test_strategy=standalone``: Disable sandboxing for tests as well.
-* ``--local_resources=1536,1.5,0.5``: Set Bazel limits on available RAM in MB,
-  available cores for compute, and available cores for I/O. Higher values
-  mean a faster build, but higher contention and risk of OOM kill.
-* ``--noshow_progress``: Suppress progress messages in output for cleaner logs.
-* ``--verbose_failures``: Get more detailed failure messages.
-* ``--test_output=errors``: Show test stderr in the Travis log. Normally,
-  test output is written log files which Travis does not save or report.
-
-Downloads on Travis are relatively slow (the network is heavily
-contended), so you'll want to minimize the amount of network I/O in
-your build. Downloading Bazel and a Go SDK is a huge part of that. To
-avoid downloading a Go SDK, you may request a container with a
-preinstalled version of Go in your ``.travis.yml`` file, then call
-``go_register_toolchains(go_version = "host")`` in a Travis-specific
-``WORKSPACE`` file.
-
-You may be tempted to put Bazel's cache in your Travis cache. Although this
-can speed up your build significantly, Travis stores its cache on Amazon, and
-it takes a very long time to transfer. Clean builds seem faster in practice.
 
 How do I test a beta version of the Go SDK?
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
It was added eight years ago in #1014. Since then, Travis has become less popular, so it's not worth the burden of maintaining this section.
It's strange that we document this one particular CI platform and not others like CircleCI or GitHub Actions. Also, this documentation isn't really Go-specific.

**What type of PR is this?**

> New Year's resolution

