### PR TITLE
Undo API-breaking change to go_sdk experiments attribute

### DIFF
--- a/go/private/rules/sdk.bzl
+++ b/go/private/rules/sdk.bzl
@@ -25,7 +25,7 @@ def _go_sdk_impl(ctx):
     return [GoSDK(
         goos = ctx.attr.goos,
         goarch = ctx.attr.goarch,
-        experiments = ctx.attr.experiments,
+        experiments = ",".join(ctx.attr.experiments),
         root_file = ctx.file.root_file,
         package_list = package_list,
         libs = depset(ctx.files.libs),
@@ -47,9 +47,9 @@ go_sdk = rule(
             mandatory = True,
             doc = "The host architecture the SDK was built for",
         ),
-        "experiments": attr.string(
+        "experiments": attr.string_list(
             mandatory = False,
-            doc = "Comma-separated Go experiments to enable via GOEXPERIMENT",
+            doc = "Go experiments to enable via GOEXPERIMENT",
         ),
         "root_file": attr.label(
             mandatory = True,

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -516,7 +516,7 @@ def _sdk_build_file(ctx, platform, version, experiments):
             "{goarch}": goarch,
             "{exe}": ".exe" if goos == "windows" else "",
             "{version}": version,
-            "{experiments}": repr(",".join(experiments)),
+            "{experiments}": repr(experiments),
             "{exec_compatible_with}": repr([
                 GOARCH_CONSTRAINTS[goarch],
                 GOOS_CONSTRAINTS[goos],


### PR DESCRIPTION
**What type of PR is this?**

Bug fix, see https://github.com/bazel-contrib/rules_go/pull/4022#issuecomment-2566548860

**What does this PR do? Why is it needed?**

Reverts the behavior to the API while keeping the optimization

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
