### PR TITLE
docs: update core link reference from .bzl to .rst

### DIFF
--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -10,7 +10,7 @@ Go toolchains
 .. _binary distribution: https://golang.org/dl/
 .. _compilation modes: modes.rst#compilation-modes
 .. _control the version: `Forcing the Go version`_
-.. _core: core.bzl
+.. _core: core.rst
 .. _forked version of Go: `Registering a custom SDK`_
 .. _go assembly: https://golang.org/doc/asm
 .. _go sdk rules: `The SDK`_


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
This PR fixes a broken documentation link by updating the reference to the core file from `core.bzl` to `core.rst`. This ensures readers are directed to the correct documentation file when clicking on the core reference link in `toolchains.rst`.

**Which issues(s) does this PR fix?**
None

**Other notes for review**
None