### PR TITLE
Put absolute paths into -extldflags

### DIFF
--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -154,11 +154,23 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 			break
 		}
 	}
+	absoluteLdFlags, nonAbsoluteLdFlags, err := splitAbsEnvVar(os.Getenv("CGO_LDFLAGS"), cgoAbsEnvFlags)
+	if err != nil {
+		return fmt.Errorf("error splitting cgo ldflags: %v", err)
+	}
+	os.Setenv("CGO_LDFLAGS", nonAbsoluteLdFlags)
+	if len(absoluteLdFlags) > 0 {
+		ldflags = append(ldflags, "-extldflags")
+		splitFlags := strings.Split(absoluteLdFlags, " ")
+		absArgs(splitFlags, cgoAbsEnvFlags)
+		ldflags = append(ldflags, splitFlags...)
+	}
+
 	installArgs = append(installArgs, "-gcflags="+allSlug+strings.Join(gcflags, " "))
 	installArgs = append(installArgs, "-ldflags="+allSlug+strings.Join(ldflags, " "))
 	installArgs = append(installArgs, "-asmflags="+allSlug+strings.Join(asmflags, " "))
 
-	if err := absCCCompiler(cgoEnvVars, cgoAbsEnvFlags); err != nil {
+	if err := absCCCompiler(cgoAbsEnvVars, cgoAbsEnvFlags); err != nil {
 		return fmt.Errorf("error modifying cgo environment to absolute path: %v", err)
 	}
 

--- a/go/tools/builders/stdliblist.go
+++ b/go/tools/builders/stdliblist.go
@@ -257,7 +257,7 @@ func stdliblist(args []string) error {
 	}
 	os.Setenv("CC", quotePathIfNeeded(abs(ccEnv)))
 
-	if err := absCCCompiler(cgoEnvVars, cgoAbsEnvFlags); err != nil {
+	if err := absCCCompiler(cgoAbsEnvVars, cgoAbsEnvFlags); err != nil {
 		return fmt.Errorf("error modifying cgo environment to absolute path: %v", err)
 	}
 


### PR DESCRIPTION
Bug fix

The go build system stores information about build flags (and environment variables) in the "_go_.o" file (go package manifest). When you use cgo, data from "CGO_LDFLAGS" is added to this file as is and used during linking (in the "ld" command). If you add absolute path to "CGO_LDFLAGS" environment, it will be save inside manifest too. However, when using a distributed build system such as BuildBarn, different build agents not share all paths (such as "bazel sandboxing" paths). If the "_go_.o" file inside go library contains non-existent paths, linking with this module fails.

This patch puts all flags with absolute paths into `-extldflags`. In this case its not stored in the go package manifest.

Problem can be reproduced only on specific cases (we use custom sysroot and distributed build system) so I don't know how to write good "common" test.
