### PR TITLE
Build stdlib with msan support

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -133,6 +133,8 @@ def _build_stdlib(go):
     args.add_all("-out", [pkg], map_each = _dirname, expand_directories = False)
     if go.mode.race:
         args.add("-race")
+    if go.mode.msan:
+        args.add("-msan")
     args.add("-package", "std")
     if not go.mode.pure:
         args.add("-package", "runtime/cgo")

--- a/go/tools/builders/stdlib.go
+++ b/go/tools/builders/stdlib.go
@@ -31,6 +31,7 @@ func stdlib(args []string) error {
 	goenv := envFlags(flags)
 	out := flags.String("out", "", "Path to output go root")
 	race := flags.Bool("race", false, "Build in race mode")
+	msan := flags.Bool("msan", false, "Build in msan mode")
 	shared := flags.Bool("shared", false, "Build in shared mode")
 	dynlink := flags.Bool("dynlink", false, "Build in dynlink mode")
 	pgoprofile := flags.String("pgoprofile", "", "Build with pgo using the given pprof file")
@@ -129,6 +130,9 @@ You may need to use the flags --cpu=x64_windows --compiler=mingw-gcc.`)
 	asmflags := []string{"-trimpath", output}
 	if *race {
 		installArgs = append(installArgs, "-race")
+	}
+	if *msan {
+		installArgs = append(installArgs, "-msan")
 	}
 	if *pgoprofile != "" {
 		gcflags = append(gcflags, "-pgoprofile=" + abs(*pgoprofile))


### PR DESCRIPTION
Bug fix

When you enable the "msan" mode in configuration, go stdlib should also be built with the "msan" flag.