### PR TITLE
Disable mac CI, update Linux

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -2,7 +2,6 @@
 matrix:
   platform:
     - ubuntu2404
-    - macos
     - macos_arm64
     - windows
 
@@ -190,8 +189,8 @@ tasks:
     test_targets:
       - "//..."
   macos_examples:
-    name: Examples test on MacOS
-    platform: macos
+    name: Examples test on macOS
+    platform: macos_arm64
     working_directory: examples/basic-gazelle
     build_flags:
       - "--config=incompatible"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,14 +1,14 @@
 ---
 matrix:
   platform:
-    - ubuntu2004
+    - ubuntu2404
     - macos
     - macos_arm64
     - windows
 
 tasks:
-  ubuntu1804_bazel6:
-    platform: ubuntu1804
+  debian11_bazel6:
+    platform: debian11
     bazel: 6.5.0 # test minimum supported version of bazel
     build_targets:
       - "//..."
@@ -21,7 +21,7 @@ tasks:
       - "-//tests/runfiles:runfiles_test"
       # TODO: Investigate why this fails.
       - "-//tests/core/starlark/cgo:missing_cc_toolchain_explicit_pure_off_test"
-  ubuntu2004:
+  ubuntu2404:
     # enable some unflipped incompatible flags on this platform to ensure we don't regress.
     build_flags:
       - "--config=incompatible"
@@ -72,21 +72,21 @@ tasks:
       - "@go_default_sdk//..."
     test_targets:
       - "//..."
-  macos_arm64:
-    build_flags:
-      - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
-      - "--crosstool_top=@local_config_apple_cc//:toolchain"
-      - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
-    build_targets:
-      - "//..."
-      - "--"
-    test_flags:
-      - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
-      - "--crosstool_top=@local_config_apple_cc//:toolchain"
-      - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
-    test_targets:
-      - "//..."
-  rbe_ubuntu1604:
+  # macos_arm64:
+  #   build_flags:
+  #     - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
+  #     - "--crosstool_top=@local_config_apple_cc//:toolchain"
+  #     - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
+  #   build_targets:
+  #     - "//..."
+  #     - "--"
+  #   test_flags:
+  #     - "--apple_crosstool_top=@local_config_apple_cc//:toolchain"
+  #     - "--crosstool_top=@local_config_apple_cc//:toolchain"
+  #     - "--host_crosstool_top=@local_config_apple_cc//:toolchain"
+  #   test_targets:
+  #     - "//..."
+  rbe_ubuntu2404:
     build_targets:
       - "//..."
     test_flags:
@@ -179,7 +179,7 @@ tasks:
   # The following configurations test a seperate WORKSPACE under the examples folder
   ubuntu2004_examples:
     name: Examples test on Ubuntu
-    platform: ubuntu2004
+    platform: ubuntu2404
     working_directory: examples/basic-gazelle
     build_flags:
       - "--config=incompatible"


### PR DESCRIPTION
While https://github.com/bazelbuild/continuous-integration/issues/2153 is still on going, this PR temporarily disable the failing macOS CI task, so the master branch is green

While I am on it, I also updated 
* The main Linux platform to ubuntu2404
* Bazel 6 test to use Debian 11 because Ubuntu 1804 is already EOF. Debian 11 is old enough to support Bazel 6 but still continue to receive security fixes
* rbe_ubuntu1604 to rbe_ubuntu2404
* all new MacBooks in the past 4 years are using ARM64. We can safely stop testing Intel Mac now 