### PR TITLE
Improve the comment for `go_sdk.host()` in the installation docs

### DIFF
--- a/docs/go/core/bzlmod.md
+++ b/docs/go/core/bzlmod.md
@@ -33,14 +33,14 @@ go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 # Download an SDK for the host OS & architecture as well as common remote execution platforms.
 go_sdk.download(version = "1.23.1")
 
-# Alternately, download an SDK for a fixed OS/architecture.
+# Alternatively, download an SDK for a fixed OS/architecture.
 go_sdk.download(
     version = "1.23.1",
     goarch = "amd64",
     goos = "linux",
 )
 
-# Register the Go SDK installed on the host.
+# Another alternative is to register the Go SDK installed on the host (see the nota bene below).
 go_sdk.host()
 ```
 


### PR DESCRIPTION
**What type of PR is this?**

Documentation

**What does this PR do?**

Explicitly call out `go_sdk.host()` as an alternative to `go_sdk.download()` in the Bzlmod installation documentation, and point clearly to the nota bene associated with it.

**What does this PR do? Why is it needed?**

Avoiding people from copying and pasting the code without understanding that `go_sdk.host()` should be omitted when using `go_sdk.download()` (as well as making sure that there's a clear pointer to its drawbacks).

**Which issues(s) does this PR fix?**

N/A
