### PR TITLE
Allow .so files to have more extensions

### DIFF
--- a/go/private/common.bzl
+++ b/go/private/common.bzl
@@ -123,15 +123,27 @@ def has_simple_shared_lib_extension(path):
     """
     return any([path.endswith(ext) for ext in SHARED_LIB_EXTENSIONS])
 
+def is_valid_shared_lib_version_part(part):
+    """
+    Checks if the version part is valid. Matches the same check from
+    //src/main/java/com/google/devtools/build/lib/rules/cpp:CppFileTypes.java
+    """
+    if not part[:1].isdigit():
+        return False
+    for c in part[1:].elems():
+        if c != "_" and not c.isalnum():
+            return False
+    return True
+
 def get_versioned_shared_lib_extension(path):
     """If appears to be an versioned .so or .dylib file, return the extension; otherwise empty"""
     parts = path.split("/")[-1].split(".")
-    if not parts[-1].isdigit():
+    if not is_valid_shared_lib_version_part(parts[-1]):
         return ""
 
     # only iterating to 1 because parts[0] has to be the lib name
     for i in range(len(parts) - 1, 0, -1):
-        if not parts[i].isdigit():
+        if not is_valid_shared_lib_version_part(parts[i]):
             if parts[i] == "dylib" or parts[i] == "so":
                 return ".".join(parts[i:])
 

--- a/tests/core/starlark/common_tests.bzl
+++ b/tests/core/starlark/common_tests.bzl
@@ -15,7 +15,7 @@ def _versioned_shared_libraries_test(ctx):
     asserts.true(env, has_shared_lib_extension("somelibrary✅.so.2.1"))
     asserts.false(env, has_shared_lib_extension("somelibrary.so.e"))
     asserts.false(env, has_shared_lib_extension("xx.1"))
-    asserts.false(env, has_shared_lib_extension("somelibrary.so.2e"))
+    asserts.true(env, has_shared_lib_extension("somelibrary.so.2e"))
     asserts.false(env, has_shared_lib_extension("somelibrary.so.e2"))
     asserts.false(env, has_shared_lib_extension("somelibrary.so.20.e2"))
     asserts.false(env, has_shared_lib_extension("somelibrary.a.2"))
@@ -25,6 +25,12 @@ def _versioned_shared_libraries_test(ctx):
     asserts.false(env, has_shared_lib_extension("somelibrary.so.2🚫"))
     asserts.false(env, has_shared_lib_extension("somelibrary.so.🚫2"))
     asserts.false(env, has_shared_lib_extension("somelibrary.so🚫.2.0"))
+    asserts.false(env, has_shared_lib_extension("somelibrary.so.2$"))
+    asserts.true(env, has_shared_lib_extension("somelibrary.so.1a_b2"))
+    asserts.false(env, has_shared_lib_extension("libA.so.gen.empty.def"))
+    asserts.false(env, has_shared_lib_extension("libA.so.if.exp"))
+    asserts.false(env, has_shared_lib_extension("libA.so.if.lib"))
+    asserts.true(env, has_shared_lib_extension("libaws-c-s3.so.0unstable"))
 
     return unittest.end(env)
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR relaxes requirements on shared libraries' versions to be in line with bazelbuild/bazel#10148. Some prebuilt libraries have non-digit versions, and we need to allow those.

**Which issues(s) does this PR fix?**

Fixes #4227.

**Other notes for review**

Bazel uses a regular expression to match version, which is not available in Starlark. I believe this implementation matches it exactly, but if you see some discrepancy — lets see what we can do.

I've also left extra tests that we already had here and added a case that checks library name mentioned in #4227. In result they are not sorted now, but Bazel's implementation does not sort its tests either 🤷 