### PR TITLE
Keep order for PATH components

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -890,7 +890,7 @@ def _cgo_context_data_impl(ctx):
     for tool_path in tool_paths:
         tool_dir = tool_path[:tool_path.rfind("/")]
         path_set[tool_dir] = None
-    paths = sorted(path_set.keys())
+    paths = path_set.keys()
     if ctx.configuration.host_path_separator == ":":
         # HACK: ":" is a proxy for a UNIX-like host.
         # The tools returned above may be bash scripts that reference commands


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

The starlark `dict` already will return items in the order in which they where inserted on iteration. There is no need to explicitly sort the items. But it does break use cases, where the user has explicitly defined a order of `PATH` components. As for example is possible with the `env` attribute of `cc_args()` with the new `rule_cc` based toolchains.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
