### PR TITLE
Capturing elapsed time of interrupted test cases due to timeout

### DIFF
--- a/go/tools/bzltestutil/testdata/timeout.json
+++ b/go/tools/bzltestutil/testdata/timeout.json
@@ -1,0 +1,26 @@
+{"Time":"2025-02-07T17:15:47.557152-08:00","Action":"start","Package":"pkg/testing"}
+{"Time":"2025-02-07T17:15:48.107123-08:00","Action":"run","Package":"pkg/testing","Test":"TestReport"}
+{"Time":"2025-02-07T17:15:48.107189-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport","Output":"=== RUN   TestReport\n"}
+{"Time":"2025-02-07T17:15:48.107222-08:00","Action":"run","Package":"pkg/testing","Test":"TestReport/test_0"}
+{"Time":"2025-02-07T17:15:48.107227-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_0","Output":"=== RUN   TestReport/test_0\n"}
+{"Time":"2025-02-07T17:15:50.108298-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_0","Output":"--- PASS: TestReport/test_0 (2.00s)\n"}
+{"Time":"2025-02-07T17:15:50.108365-08:00","Action":"pass","Package":"pkg/testing","Test":"TestReport/test_0","Elapsed":2}
+{"Time":"2025-02-07T17:15:50.108385-08:00","Action":"run","Package":"pkg/testing","Test":"TestReport/test_1"}
+{"Time":"2025-02-07T17:15:50.108392-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_1","Output":"=== RUN   TestReport/test_1\n"}
+{"Time":"2025-02-07T17:15:52.1095-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_1","Output":"--- PASS: TestReport/test_1 (2.00s)\n"}
+{"Time":"2025-02-07T17:15:52.109693-08:00","Action":"pass","Package":"pkg/testing","Test":"TestReport/test_1","Elapsed":2}
+{"Time":"2025-02-07T17:15:52.109806-08:00","Action":"run","Package":"pkg/testing","Test":"TestReport/test_2"}
+{"Time":"2025-02-07T17:15:52.109841-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_2","Output":"=== RUN   TestReport/test_2\n"}
+{"Time":"2025-02-07T17:15:54.110684-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_2","Output":"--- PASS: TestReport/test_2 (2.00s)\n"}
+{"Time":"2025-02-07T17:15:54.110864-08:00","Action":"pass","Package":"pkg/testing","Test":"TestReport/test_2","Elapsed":2}
+{"Time":"2025-02-07T17:15:54.1109-08:00","Action":"run","Package":"pkg/testing","Test":"TestReport/test_3"}
+{"Time":"2025-02-07T17:15:54.110923-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"=== RUN   TestReport/test_3\n"}
+{"Time":"2025-02-07T17:15:56.110984-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"panic: test timed out after 8s\n"}
+{"Time":"2025-02-07T17:15:56.11102-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"\trunning tests:\n"}
+{"Time":"2025-02-07T17:15:56.111039-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"\t\tTestReport (8s)\n"}
+{"Time":"2025-02-07T17:15:56.111046-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"\t\tTestReport/test_3 (2s)\n"}
+{"Time":"2025-02-07T17:15:56.111051-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"\n"}
+{"Time":"2025-02-07T17:15:56.111056-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"goroutine 33 [running]:\n"}
+{"Time":"2025-02-07T17:15:56.111067-08:00","Action":"output","Package":"pkg/testing","Test":"TestReport/test_3","Output":"testing.(*M).startAlarm.func1()\n"}
+{"Time":"2025-02-07T17:15:56.11168-08:00","Action":"output","Package":"pkg/testing","Output":"FAIL\tpkg/testing\t8.554s\n"}
+{"Time":"2025-02-07T17:15:56.111693-08:00","Action":"fail","Package":"pkg/testing","Elapsed":8.555}

--- a/go/tools/bzltestutil/testdata/timeout.xml
+++ b/go/tools/bzltestutil/testdata/timeout.xml
@@ -1,0 +1,13 @@
+<testsuites>
+	<testsuite errors="2" failures="0" skipped="0" tests="5" time="8.555" name="pkg/testing">
+		<testcase classname="testing" name="TestReport" time="8.000">
+			<error message="Interrupted" type="">=== RUN   TestReport&#xA;&#x9;&#x9;TestReport (8s)&#xA;</error>
+		</testcase>
+		<testcase classname="testing" name="TestReport/test_0" time="2.000"></testcase>
+		<testcase classname="testing" name="TestReport/test_1" time="2.000"></testcase>
+		<testcase classname="testing" name="TestReport/test_2" time="2.000"></testcase>
+		<testcase classname="testing" name="TestReport/test_3" time="2.000">
+			<error message="Interrupted" type="">=== RUN   TestReport/test_3&#xA;&#x9;&#x9;TestReport/test_3 (2s)&#xA;goroutine 33 [running]:&#xA;testing.(*M).startAlarm.func1()&#xA;</error>
+		</testcase>
+	</testsuite>
+</testsuites>


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
When a test case is interrupted at timeout, we don't have the pass/fail/skip event to report elapsed time. However, we can parse them from the error message at the end to figure it out. The error message looks like:

```
panic: test timed out after 8s
        running tests:
                TestReport (8s)
                TestReport/test_3 (2s)
```

Also, instead of reporting those test cases as "No pass/skip/fail event found for test", we can now report them as "Interrupted".
