### PR TITLE
Populate timestamp in test.xml

### DIFF
--- a/go/tools/bzltestutil/testdata/timeout.xml
+++ b/go/tools/bzltestutil/testdata/timeout.xml
@@ -1,5 +1,5 @@
 <testsuites>
-	<testsuite errors="2" failures="0" skipped="0" tests="5" time="8.555" name="pkg/testing">
+	<testsuite errors="2" failures="0" skipped="0" tests="5" time="8.555" name="pkg/testing" timestamp="2025-02-07T17:15:47.557Z">
 		<testcase classname="testing" name="TestReport" time="8.000">
 			<error message="Interrupted" type="">=== RUN   TestReport&#xA;&#x9;&#x9;TestReport (8s)&#xA;</error>
 		</testcase>


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
The <testsuite> element in JUnit XML has a `timestamp` attribute, but the `<testcase>` doesn't, while Go test's json has the timestamp for every event. This PR find the smallest timestamp in the json events and use that as the `timestamp` of `<testsuite>`.

**Test plan**
* Unit test
* Verify that the timestamps are different with `--runs_per_test=10`