### PR TITLE
Mark gomock() hidden targets manual

### DIFF
--- a/extras/gomock.bzl
+++ b/extras/gomock.bzl
@@ -241,12 +241,14 @@ def _gomock_reflect(name, library, out, mockgen_tool, **kwargs):
         library = library,
         out = prog_src_out,
         mockgen_tool = mockgen_tool,
+        tags = ["manual"],
     )
     prog_bin = name + "_gomock_prog_bin"
     go_binary(
         name = prog_bin,
         srcs = [prog_src_out],
         deps = [library, mockgen_model_lib],
+        tags = ["manual"],
     )
     _gomock_prog_exec(
         name = name,


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Imagine if you want to build mocks for interfaces that are only available on certain operating systems/hardware platforms. In those cases you simply want to add a "manual" tag to the gomock() target, and only rely on it getting built if the resulting Go source file is part of some go_library().

This change adds the "manual" tag to all of the hidden targets of this rule, meaning that their build is skipped completely if the main gomock() target is marked manual as well.

**Which issues(s) does this PR fix?**

One that requires me to carry a local patch around on the github.com/buildbarn/bb-remote-execution side.

**Other notes for review**
