### PR TITLE
Bug fix: proto: add gofeaturespb as well-known type; Go Protobuf ships it

### DIFF
--- a/proto/wkt/well_known_types.bzl
+++ b/proto/wkt/well_known_types.bzl
@@ -59,6 +59,7 @@ PROTO_RUNTIME_DEPS = [
 # on the APIv1 packages.
 WELL_KNOWN_TYPES_APIV2 = [
     "@org_golang_google_protobuf//types/descriptorpb",
+    "@org_golang_google_protobuf//types/gofeaturespb",
     "@org_golang_google_protobuf//types/known/anypb",
     "@org_golang_google_protobuf//types/known/apipb",
     "@org_golang_google_protobuf//types/known/durationpb",


### PR DESCRIPTION
go_features.proto was introduced with Go Protobuf v1.33.0 (March 2024): https://github.com/protocolbuffers/protobuf-go/commit/2040e8671baa910b9a9c91fa21a2543846772985

…but with the release of the Go Protobuf Opaque API in December 2024, more users will be interested in making use of this file to configure the generated API that their .proto files should use.

Without this change, building a go_proto_library() whose .proto sets the API level to the Opaque API as documented at https://protobuf.dev/reference/go/opaque-migration/ would fail with this error message:

  compilepkg: missing strict dependencies:
  …/execroot/_main/bazel-out/k8-fastbuild/bin/dumbdata_go_proto_/
  github.com/cshabsin/nih/dumbdata_go_proto/dumb_data.pb.go:
  import of "google.golang.org/protobuf/types/gofeaturespb"
  No dependencies were provided.

For https://github.com/golang/protobuf/issues/1679