### PR TITLE
fix(gopackagesdriver): Improve wildcard package query matching

### DIFF
--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -116,7 +116,7 @@ func (b *BazelJSONBuilder) adjustToRelativePathIfPossible(request string) string
 
 func (b *BazelJSONBuilder) packageQuery(importPath string) string {
 	if strings.HasSuffix(importPath, "/...") {
-		importPath = fmt.Sprintf(`^%s(/.+)?$`, strings.TrimSuffix(importPath, "/..."))
+		importPath = fmt.Sprintf(`%s(/.+)?$`, strings.TrimSuffix(importPath, "/..."))
 	}
 
 	return fmt.Sprintf(


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Improve wildcard package loading (`./something/...`) when using a custom bazelQueryScope e.g. `//...`. Currently, the queryFromRequests transformation results in a query like:

```
bazel query "kind(\"^(go_library) rule$\", attr(importpath, \"^./something(/.+)?$\", deps(//...)))"
```

which fails to return any results due to the `^` start of string matching. This PR also aligns the behaviour more closely to the "non wild card" behaviour ([see](https://github.com/bazel-contrib/rules_go/blob/077f15fe11b9da6aa0e3271db1260929f04fef87/go/tools/gopackagesdriver/bazel_json_builder.go#L123)) by omitting the `^`.

When using go outside bazel, the following query is valid syntax and correctly loads all the packages under `./something/`:

```
package.Load(cfg, "./something/...")
```

**Which issues(s) does this PR fix?**

No issue

**Other notes for review**
