### PR TITLE
add workspaceFiles to vim configuration documentation

### DIFF
--- a/docs/go/editors/vim.md
+++ b/docs/go/editors/vim.md
@@ -40,6 +40,11 @@ autocompletion for Bazel-generated Go files, among other things.
 
       " See https://github.com/golang/tools/blob/master/gopls/doc/settings.md
       let g:go_gopls_settings = {
+        \ 'build.workspaceFiles': [
+          \ '**/BUILD',
+          \ '**/WORKSPACE',
+          \ '**/*.{bzl,bazel}',
+        \ ], 
         \ 'build.directoryFilters': [
           \ '-bazel-bin',
           \ '-bazel-out',


### PR DESCRIPTION
**What type of PR is this?**
Documentation

**What does this PR do? Why is it needed?**
Adds `gopls.build.workspaceFiles` to the Vim documentation, following the merge of the `build.workspaceFiles` option in [gopls v0.18.0](https://github.com/golang/tools/releases/tag/gopls%2Fv0.18.0), which aims to improve editor integration with Bazel projects.

**Which issues(s) does this PR fix?**
Fixes #4289 

**Other notes for review**
These configuration changes have already been applied to the https://github.com/bazel-contrib/rules_go/wiki/Editor-setup wiki page, so this is just keeping everything in-sync.
