### PR TITLE
Fix goos and goarch options in go_wrap_sdk

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -403,15 +403,15 @@ _go_wrap_sdk = repository_rule(
 )
 
 def go_wrap_sdk(name, register_toolchains = True, **kwargs):
-    _go_wrap_sdk(name = name, **kwargs)
     _go_toolchains(
         name = name + "_toolchains",
         sdk_repo = name,
         sdk_type = "remote",
         sdk_version = kwargs.get("version"),
-        goos = kwargs.get("goos"),
-        goarch = kwargs.get("goarch"),
+        goos = kwargs.pop("goos", None),
+        goarch = kwargs.pop("goarch", None),
     )
+    _go_wrap_sdk(name = name, **kwargs)
     if register_toolchains:
         _register_toolchains(name)
 


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**

I am using `go_wrap_sdk` for a single toolchain override that only works on linux/amd64. Passing goos and goarch results in an error because _go_wrap_sdk does not have those attributes.