### PR TITLE
fix the reporting message for getFixes

### DIFF
--- a/go/tools/builders/nogo_fix.go
+++ b/go/tools/builders/nogo_fix.go
@@ -84,22 +84,13 @@ func applyEdits(src []byte, edits []nogoEdit) []byte {
 // getFixes merges the suggested fixes from all analyzers, returns one fileChange object per file,
 // while reporting conflicts as error.
 func getFixes(entries []diagnosticEntry, fileSet *token.FileSet) ([]fileChange, error) {
-	hasFixes := false
-	for _, entry := range entries {
-		if len(entry.Diagnostic.SuggestedFixes) > 0 {
-			hasFixes = true
-			break
-		}
-	}
-	if !hasFixes {
-		// there is no error in terms of getting the fixes, so we don't report an error.
-		return nil, nil
-	}
-
 	var allErrors []error
 	finalChanges := make(map[string][]nogoEdit)
 
 	for _, entry := range entries {
+		if len(entry.Diagnostic.SuggestedFixes) == 0 {
+			continue
+		}
 		// According to the [doc](https://pkg.go.dev/golang.org/x/tools@v0.28.0/go/analysis#Diagnostic),
 		// an analyzer may suggest several alternative fixes, but only one should be applied.
 		// We will go over all the suggested fixes until the we find one with no conflict

--- a/go/tools/builders/nogo_fix_test.go
+++ b/go/tools/builders/nogo_fix_test.go
@@ -177,9 +177,11 @@ func TestGetFixes_Conflict(t *testing.T) {
 		},
 	}
 	expectedError := `ignoring suggested fixes from analyzer "analyzer2"`
+	detailedExpectedError := `details about errors on each of the suggested fixes: [overlapping suggestions from "analyzer2" and "analyzer1" at {Start:54,End:61,New:""} and {Start:54,End:62,New:""}]`
+
 	fileChanges, err := getFixes(diagnosticEntries, fset)
-	if err == nil || !strings.Contains(err.Error(), expectedError) {
-		t.Errorf("expected error: %s\ngot:%v+", expectedError, err)
+	if err == nil || !strings.Contains(err.Error(), expectedError) || !strings.Contains(err.Error(), detailedExpectedError) {
+		t.Errorf("expected errors: %s or %s\ngot:%v+", expectedError, detailedExpectedError, err)
 	}
 	expectedChanges := []fileChange{
 		{
@@ -192,6 +194,28 @@ func TestGetFixes_Conflict(t *testing.T) {
 	}
 	if !reflect.DeepEqual(fileChanges, expectedChanges) {
 		t.Errorf("unexpected changes:\n\tgot:\t%v\n\twant:\t%v", fileChanges, expectedChanges)
+	}
+}
+
+func TestGetFixes_NoFixes(t *testing.T) {
+	fset := token.NewFileSet()
+
+	diagnosticEntries := []diagnosticEntry{
+		{
+			analyzerName: "analyzer1",
+			Diagnostic: analysis.Diagnostic{
+				SuggestedFixes: []analysis.SuggestedFix{},
+			},
+		},
+	}
+
+	fileChanges, err := getFixes(diagnosticEntries, fset)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if fileChanges != nil {
+		t.Errorf("expected no file changes, got: %v", fileChanges)
 	}
 }
 

--- a/go/tools/builders/nogo_fix_test.go
+++ b/go/tools/builders/nogo_fix_test.go
@@ -177,7 +177,8 @@ func TestGetFixes_Conflict(t *testing.T) {
 		},
 	}
 	expectedError := `ignoring suggested fixes from analyzer "analyzer2"`
-	detailedExpectedError := `details about errors on each of the suggested fixes: [overlapping suggestions from "analyzer2" and "analyzer1" at {Start:54,End:61,New:""} and {Start:54,End:62,New:""}]`
+	detailedExpectedError := `because:
+	- overlapping suggestions from "analyzer2" and "analyzer1" at {Start:54,End:61,New:""} and {Start:54,End:62,New:""}`
 
 	fileChanges, err := getFixes(diagnosticEntries, fset)
 	if err == nil || !strings.Contains(err.Error(), expectedError) || !strings.Contains(err.Error(), detailedExpectedError) {


### PR DESCRIPTION
**What type of PR is this?**
Improve the report message to avoid confusing developers.


> Bug fix


**What does this PR do? Why is it needed?**
Two issues:
- issue if there are no fixes at all, getFixes still produces "some suggested fixes are invalid or have conflicts with other fixes:". The right behavior is to not produce such message.
- if there are multiple suggested fixes, getFixes produces "some suggested fixes are invalid or have conflicts with other fixes:". A better solution is to, for each suggested fix, records how it fails (invalid or conflicting). 


**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
