### PR TITLE
Add `go_sdk.from_file` to read the SDK version from `go.mod`.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,9 +16,9 @@ bazel_dep(name = "protobuf", version = "3.19.2", repo_name = "com_google_protobu
 bazel_dep(name = "rules_shell", version = "0.3.0")
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
-go_sdk.download(
+go_sdk.from_file(
     name = "go_default_sdk",
-    version = "1.23.6",
+    go_mod = "//:go.mod",
 )
 use_repo(
     go_sdk,

--- a/docs/go/core/bzlmod.md
+++ b/docs/go/core/bzlmod.md
@@ -30,7 +30,12 @@ To register a particular version of the Go SDK, use the `go_sdk` module extensio
 ```starlark
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
 
-# Download an SDK for the host OS & architecture as well as common remote execution platforms.
+# Download an SDK for the host OS & architecture as well as common remote execution
+# platforms, using the version given from the `go.mod` file.
+go_sdk.from_file(go_mod = "//:go.mod")
+
+# Download an SDK for the host OS & architecture as well as common remote execution
+# platforms, with a specific version.
 go_sdk.download(version = "1.23.1")
 
 # Alternatively, download an SDK for a fixed OS/architecture.

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -215,7 +215,7 @@ def _go_sdk_impl(ctx):
                 sdk_version = wrap_tag.version,
             ))
 
-        # First if the module suggests to read the toolchain version from a `go.mod` file, use that.
+        # If the module suggests to read the toolchain version from a `go.mod` file, use that.
         for index, from_file_tag in enumerate(module.tags.from_file):
             version = version_from_go_mod(ctx, from_file_tag.go_mod)
             name = from_file_tag.name or _default_go_sdk_name(

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -56,6 +56,7 @@ _COMMON_TAG_ATTRS = {
 }
 
 _download_tag = tag_class(
+    doc = """Download a specific Go SDK at the optional GOOS, GOARCH, and version, from a customisable URL.  Optionally apply local customisations to the SDK though patches and experiments.""",
     attrs = _COMMON_TAG_ATTRS | {
         "version": attr.string(),
     },
@@ -117,6 +118,7 @@ _wrap_tag = tag_class(
 )
 
 _from_file_tag = tag_class(
+    doc = """Use a specific Go SDK version described by a `go.mod` file.  Optionally supply GOOS, GOARCH, and download from a customisable URL, with any local patches or experiments applied.""",
     attrs = _COMMON_TAG_ATTRS | {
         "go_mod": attr.label(
             doc = "The go.mod file to read the SDK version from.",

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -218,7 +218,6 @@ def _go_sdk_impl(ctx):
         # First if the module suggests to read the toolchain version from a `go.mod` file, use that.
         for index, from_file_tag in enumerate(module.tags.from_file):
             version = version_from_go_mod(ctx, from_file_tag.go_mod)
-            print("Got version {}".format(version))
             name = from_file_tag.name or _default_go_sdk_name(
                 module = module,
                 multi_version = multi_version_module[module.name],
@@ -364,9 +363,6 @@ def _go_sdk_impl(ctx):
                 sdk_version = host_tag.version,
             ))
             first_host_compatible_toolchain = first_host_compatible_toolchain or "@{}//:ROOT".format(name)
-
-    print("toolchains: {}".format(toolchains))
-    print("first : {}".format(first_host_compatible_toolchain))
 
     host_compatible_toolchain(name = "go_host_compatible_sdk_label", toolchain = first_host_compatible_toolchain)
     if len(toolchains) > _MAX_NUM_TOOLCHAINS:

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -56,7 +56,7 @@ _COMMON_TAG_ATTRS = {
 }
 
 _download_tag = tag_class(
-    doc = """Download a specific Go SDK at the optional GOOS, GOARCH, and version, from a customisable URL.  Optionally apply local customisations to the SDK though patches and experiments.""",
+    doc = """Download a specific Go SDK at the optional GOOS, GOARCH, and version, from a customisable URL.  Optionally apply local customisations to the SDK by applying patches and setting experiments.""",
     attrs = _COMMON_TAG_ATTRS | {
         "version": attr.string(),
     },
@@ -118,7 +118,7 @@ _wrap_tag = tag_class(
 )
 
 _from_file_tag = tag_class(
-    doc = """Use a specific Go SDK version described by a `go.mod` file.  Optionally supply GOOS, GOARCH, and download from a customisable URL, with any local patches or experiments applied.""",
+    doc = """Use a specific Go SDK version described by a `go.mod` file.  Optionally supply GOOS, GOARCH, and download from a customisable URL, and apply local patches or set experiments.""",
     attrs = _COMMON_TAG_ATTRS | {
         "go_mod": attr.label(
             doc = "The go.mod file to read the SDK version from.",
@@ -271,7 +271,7 @@ def _go_sdk_impl(ctx):
                 index = index,
             )
 
-            # Keep in sync with the other call to go_download_sdk_rule below.
+            # Keep in sync with the other calls to `go_download_sdk_rule` above and below.
             go_download_sdk_rule(
                 name = name,
                 goos = download_tag.goos,
@@ -315,6 +315,8 @@ def _go_sdk_impl(ctx):
                         index = index,
                         suffix = "_{}_{}".format(goos, goarch),
                     )
+
+                    # Keep in sync with the other calls to `go_download_sdk_rule` above.
                     go_download_sdk_rule(
                         name = default_name,
                         goos = goos,

--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -225,7 +225,7 @@ def _go_sdk_impl(ctx):
             download_tag = {
                 key: getattr(from_file_tag, key)
                 for key in dir(from_file_tag)
-                if key not in "go_mod"
+                if key not in ["go_mod"]
             }
             download_tag["version"] = version
             additional_download_tags += [struct(**download_tag)]

--- a/go/private/go_mod.bzl
+++ b/go/private/go_mod.bzl
@@ -1,0 +1,137 @@
+# Copyright 2025 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+def version_from_go_mod(module_ctx, go_mod_label):
+    """Returns a version string from a go.mod file.
+
+    Args:
+       module_ctx: a https://bazel.build/rules/lib/module_ctx object passed
+            from the MODULE.bazel call.
+       go_mod_label: a Label for a `go.mod` file.
+
+    Returns:
+      a string containing the version of the Go SDK defined in go.mod
+    """
+    _check_go_mod_name(go_mod_label.name)
+    go_mod_path = module_ctx.path(go_mod_label)
+    go_mod_content = module_ctx.read(go_mod_path)
+
+    state = {
+        "toolchain": None,
+        "go": None,
+    }
+
+    for line_no, line in enumerate(go_mod_content.splitlines(), 1):
+        tokens, _ = _tokenize_line(line, go_mod_path, line_no)
+        if not tokens:
+            continue
+
+        if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain"]:
+            fail("{}:{}: unexpected token '{}' at start of line".format(go_mod_path, line_no, tokens[0]))
+        if len(tokens) == 1:
+            fail("{}:{}: expected another token after '{}'".format(go_mod_path, line_no, tokens[0]))
+
+        if tokens[0] == "go":
+            _validate_go_version(go_mod_path, state, tokens, line_no)
+            state["go"] = tokens[1]
+
+        if tokens[0] == "toolchain":
+            _validate_toolchain_version(go_mod_path, state, tokens, line_no)
+            state["toolchain"] = tokens[1][len("go"):].strip()
+
+    version = state["toolchain"]
+    if not version:
+        version = state["go"]
+    if not version:
+        # "As of the Go 1.17 release, if the go directive is missing, go 1.16 is assumed."
+        version = "1.16"
+
+    return version
+
+def _tokenize_line(line, path, line_no):
+    tokens = []
+    r = line
+    for _ in range(len(line)):
+        r = r.strip()
+        if not r:
+            break
+
+        if r[0] == "`":
+            end = r.find("`", 1)
+            if end == -1:
+                fail("{}:{}: unterminated raw string".format(path, line_no))
+
+            tokens.append(r[1:end])
+            r = r[end + 1:]
+
+        elif r[0] == "\"":
+            value = ""
+            escaped = False
+            found_end = False
+            pos = 0
+            for pos in range(1, len(r)):
+                c = r[pos]
+
+                if escaped:
+                    value += c
+                    escaped = False
+                    continue
+
+                if c == "\\":
+                    escaped = True
+                    continue
+
+                if c == "\"":
+                    found_end = True
+                    break
+
+                value += c
+
+            if not found_end:
+                fail("{}:{}: unterminated interpreted string".format(path, line_no))
+
+            tokens.append(value)
+            r = r[pos + 1:]
+
+        elif r.startswith("//"):
+            # A comment always ends the current line
+            return tokens, r[len("//"):].strip()
+
+        else:
+            token, _, r = r.partition(" ")
+            tokens.append(token)
+
+    return tokens, None
+
+def _check_go_mod_name(name):
+    if name != "go.mod":
+        fail("go_sdk.from_file requires a 'go.mod' file, not '{}'".format(name))
+
+def _validate_go_version(path, state, tokens, line_no):
+    if len(tokens) == 1:
+        fail("{}:{}: expected another token after 'go'".format(path, line_no))
+    if state["go"] != None:
+        fail("{}:{}: unexpected second 'go' directive".format(path, line_no))
+    if len(tokens) > 2:
+        fail("{}:{}: unexpected token '{}' after '{}'".format(path, line_no, tokens[2], tokens[1]))
+
+def _validate_toolchain_version(path, state, tokens, line_no):
+    if len(tokens) == 1:
+        fail("{}:{}: expected another token after 'toolchain'".format(path, line_no))
+    if state["toolchain"] != None:
+        fail("{}:{}: unexpected second 'toolchain' directive".format(path, line_no))
+    if len(tokens) > 2:
+        fail("{}:{}: unexpected token '{}' after '{}'".format(path, line_no, tokens[2], tokens[1]))
+    if not tokens[1].startswith("go"):
+        fail("{}:{}: expected toolchain version to start with 'go', not '{}'".format(path, line_no, tokens[1]))

--- a/go/private/go_mod.bzl
+++ b/go/private/go_mod.bzl
@@ -32,23 +32,36 @@ def version_from_go_mod(module_ctx, go_mod_label):
         "go": None,
     }
 
+    current_directive = None
     for line_no, line in enumerate(go_mod_content.splitlines(), 1):
         tokens, _ = _tokenize_line(line, go_mod_path, line_no)
         if not tokens:
             continue
 
-        if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain"]:
-            fail("{}:{}: unexpected token '{}' at start of line".format(go_mod_path, line_no, tokens[0]))
-        if len(tokens) == 1:
-            fail("{}:{}: expected another token after '{}'".format(go_mod_path, line_no, tokens[0]))
+        if not current_directive:
+            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain"]:
+                fail("{}:{}: unexpected token '{}' at start of line".format(go_mod_path, line_no, tokens[0]))
+            if len(tokens) == 1:
+                fail("{}:{}: expected another token after '{}'".format(go_mod_path, line_no, tokens[0]))
 
-        if tokens[0] == "go":
-            _validate_go_version(go_mod_path, state, tokens, line_no)
-            state["go"] = tokens[1]
+            if tokens[0] == "go":
+                _validate_go_version(go_mod_path, state, tokens, line_no)
+                state["go"] = tokens[1]
 
-        if tokens[0] == "toolchain":
-            _validate_toolchain_version(go_mod_path, state, tokens, line_no)
-            state["toolchain"] = tokens[1][len("go"):].strip()
+            if tokens[0] == "toolchain":
+                _validate_toolchain_version(go_mod_path, state, tokens, line_no)
+                state["toolchain"] = tokens[1][len("go"):].strip()
+
+            if tokens[1] == "(":
+                current_directive = tokens[0]
+                if len(tokens) > 2:
+                    fail("{}:{}: unexpected token '{}' after '('".format(go_mod_path, line_no, tokens[2]))
+                continue
+        elif tokens[0] == ")":
+            current_directive = None
+            if len(tokens) > 1:
+                fail("{}:{}: unexpected token '{}' after ')'".format(go_mod_path, line_no, tokens[1]))
+            continue
 
     version = state["toolchain"]
     if not version:

--- a/go/private/go_mod.bzl
+++ b/go/private/go_mod.bzl
@@ -39,11 +39,6 @@ def version_from_go_mod(module_ctx, go_mod_label):
             continue
 
         if not current_directive:
-            if tokens[0] not in ["module", "go", "require", "replace", "exclude", "retract", "toolchain"]:
-                fail("{}:{}: unexpected token '{}' at start of line".format(go_mod_path, line_no, tokens[0]))
-            if len(tokens) == 1:
-                fail("{}:{}: expected another token after '{}'".format(go_mod_path, line_no, tokens[0]))
-
             if tokens[0] == "go":
                 _validate_go_version(go_mod_path, state, tokens, line_no)
                 state["go"] = tokens[1]

--- a/go/private/go_mod.bzl
+++ b/go/private/go_mod.bzl
@@ -65,6 +65,7 @@ def version_from_go_mod(module_ctx, go_mod_label):
 
     version = state["toolchain"]
     if not version:
+        # https://go.dev/doc/toolchain: "a go.mod that says go 1.21.0 with no toolchain line is interpreted as if it had a toolchain go1.21.0 line."
         version = state["go"]
     if not version:
         # "As of the Go 1.17 release, if the go directive is missing, go 1.16 is assumed."

--- a/tests/core/from_go_mod_file/BUILD.bazel
+++ b/tests/core/from_go_mod_file/BUILD.bazel
@@ -1,0 +1,6 @@
+load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+
+go_bazel_test(
+    name = "from_go_mod_file_test",
+    srcs = ["from_go_mod_file_test.go"],
+)

--- a/tests/core/from_go_mod_file/README.rst
+++ b/tests/core/from_go_mod_file/README.rst
@@ -1,0 +1,7 @@
+from_go_mod_file
+================
+
+from_go_mod_file_test
+---------------------
+Verifies that ``go_sdk.from_file`` can be used to fetch the Go SDK version
+that is described by the toolchain in ``go.mod``.

--- a/tests/core/from_go_mod_file/from_go_mod_file_test.go
+++ b/tests/core/from_go_mod_file/from_go_mod_file_test.go
@@ -53,7 +53,7 @@ func Test(t *testing.T) {
 `,
 		ModuleFileSuffix: `
 go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
-go_sdk.from_file(name = "go_sdk", go_mod = "//:go.mod")
+go_sdk.from_file(go_mod = "//:go.mod")
 `,
 	})
 }
@@ -73,15 +73,15 @@ toolchain go1.24.1
 `,
 			want: "go1.24.1",
 		},
-		{
-			desc: "go only",
-			go_mod: `
-module test
+// 		{
+// 			desc: "go only",
+// 			go_mod: `
+// module test
 
-go 1.23.0
-`,
-			want: "go1.23.0",
-		},
+// go 1.23.0
+// `,
+// 			want: "go1.23.0",
+// 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
 			if err := ioutil.WriteFile("go.mod", []byte(test.go_mod), 0o666); err != nil {

--- a/tests/core/from_go_mod_file/from_go_mod_file_test.go
+++ b/tests/core/from_go_mod_file/from_go_mod_file_test.go
@@ -62,49 +62,49 @@ func Test(t *testing.T) {
 	for _, test := range []struct{
 		desc, go_mod, want string
 	}{
-// 		{
-// 			desc: "toolchain",
-// 			go_mod: `
-// module test
+		{
+			desc: "toolchain",
+			go_mod: `
+module test
 
-// go 1.23.0
+go 1.23.0
 
-// toolchain go1.24.0
+toolchain go1.24.0
 
-// require (
-//     github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
-// )
-// `,
-// 			want: "go1.24.0 X:nocoverageredesign",
-// 		},
-// 		{
-// 			desc: "toolchain minor version",
-// 			go_mod: `
-// module test
+require (
+    github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
+)
+`,
+			want: "go1.24.0 X:nocoverageredesign",
+		},
+		{
+			desc: "toolchain minor version",
+			go_mod: `
+module test
 
-// go 1.23.0
+go 1.23.0
 
-// toolchain go1.24.1
+toolchain go1.24.1
 
-// require (
-//     github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
-// )
-// `,
-// 			want: "go1.24.1 X:nocoverageredesign",
-// 		},
-// 		{
-// 			desc: "go only",
-// 			go_mod: `
-// module test
+require (
+    github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
+)
+`,
+			want: "go1.24.1 X:nocoverageredesign",
+		},
+		{
+			desc: "go only",
+			go_mod: `
+module test
 
-// go 1.17
+go 1.17
 
-// require (
-//     github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
-// )
-// `,
-// 			want: "go1.23.0",
-// 		},
+require (
+    github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
+)
+`,
+			want: "go1.23.0",
+		},
 		{
 			desc: "missing go",
 			go_mod: `
@@ -114,7 +114,7 @@ require (
     github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
 )
 `,
-			want: "go1.17",
+			want: "go1.16",
 		},
 	} {
 		t.Run(test.desc, func(t *testing.T) {
@@ -126,6 +126,11 @@ require (
 				"--enable_bzlmod",
 				"--test_arg=-version=" + test.want,
 				"--test_output=all",
+				"--sandbox_debug",
+				// This feels like a hack to force the test environment to
+				// choose our SDK, because `bazel_testing` uses `go_wrap_sdk`
+				// to create its own SDK.
+				"--@io_bazel_rules_go//go/toolchain:sdk_name=sdk_under_test",
 				"//:version_test",
 			}
 			if err := bazel_testing.RunBazel(args...); err != nil {

--- a/tests/core/from_go_mod_file/from_go_mod_file_test.go
+++ b/tests/core/from_go_mod_file/from_go_mod_file_test.go
@@ -97,13 +97,13 @@ require (
 			go_mod: `
 module test
 
-go 1.17
+go 1.16
 
 require (
     github.com/bazelbuild/rules_go v0.53.0  // unused, just here to test the go.mod parser
 )
 `,
-			want: "go1.23.0",
+			want: "go1.16",
 		},
 		{
 			desc: "missing go",
@@ -123,13 +123,10 @@ require (
 			}
 			args := []string{
 				"test",
-				"--enable_bzlmod",
 				"--test_arg=-version=" + test.want,
-				"--test_output=all",
-				"--sandbox_debug",
-				// This feels like a hack to force the test environment to
-				// choose our SDK, because `bazel_testing` uses `go_wrap_sdk`
-				// to create its own SDK.
+				// This next flag forces the test environment to choose its own
+				// module's SDK, because `bazel_testing` uses `go_wrap_sdk` to
+				// create its own SDK in the WORKSPACE file.
 				"--@io_bazel_rules_go//go/toolchain:sdk_name=sdk_under_test",
 				"//:version_test",
 			}

--- a/tests/core/from_go_mod_file/from_go_mod_file_test.go
+++ b/tests/core/from_go_mod_file/from_go_mod_file_test.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package from_go_mod_file_test
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "version_test",
+    srcs = ["version_test.go"],
+)
+
+-- version_test.go --
+package version_test
+
+import (
+    "fmt"
+    "flag"
+    "runtime"
+    "testing"
+)
+
+var want = flag.String("version", "", "")
+
+func Test(t *testing.T) {
+    fmt.Println(runtime.Version())
+    if v := runtime.Version(); v != *want {
+        t.Errorf("got version %q; want %q", v, *want)
+    }
+}
+`,
+		ModuleFileSuffix: `
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.from_file(name = "go_sdk", go_mod = "//:go.mod")
+`,
+	})
+}
+
+func Test(t *testing.T) {
+	for _, test := range []struct{
+		desc, go_mod, want string
+	}{
+		{
+			desc: "toolchain",
+			go_mod: `
+module test
+
+go 1.23.0
+
+toolchain go1.24.1
+`,
+			want: "go1.24.1",
+		},
+		{
+			desc: "go only",
+			go_mod: `
+module test
+
+go 1.23.0
+`,
+			want: "go1.23.0",
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			if err := ioutil.WriteFile("go.mod", []byte(test.go_mod), 0o666); err != nil {
+				t.Fatal(err)
+			}
+			args := []string{
+				"test",
+				"//:version_test",
+				"--test_arg=-version=" + test.want,
+				"--test_output=all",
+			}
+			if err := bazel_testing.RunBazel(args...); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+
+


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Adds a `go_sdk.from_file` rule to the extension that allows modules to say that their SDK version should be read from their `go.mod` file.  This allows callers to avoid repeating themselves and stay within the Go tool environment for version specification, allowing better integration with other tools.

**Which issues(s) does this PR fix?**

Fixes #4292

**Other notes for review**

The toolchain version is selected based on the rules in https://go.dev/doc/toolchain

This change copies parts of the `go_mod.bzl` parser from the Gazelle repository:
https://github.com/bazel-contrib/bazel-gazelle/blob/master/internal/bzlmod/go_mod.bzl

A test based on the `go_download_sdk` test sets up a module-under-test with a `go.mod` and
checks that the version specified in it is used to run the test in that repo-under-test.