### PR TITLE
Producing "fail" event when a test case panics

### DIFF
--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -141,6 +141,11 @@ func Wrap(pkg string) error {
 	cmd.Stdout = io.MultiWriter(os.Stdout, streamMerger.OutW)
 	streamMerger.Start()
 	err := cmd.Run()
+	if err != nil {
+		jsonConverter.Write([]byte{marker})
+		jsonConverter.Write(bigFail)
+		jsonConverter.Write([]byte("\n"))
+	}
 	streamMerger.ErrW.Close()
 	streamMerger.OutW.Close()
 	streamMerger.Wait()

--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -142,6 +142,7 @@ func Wrap(pkg string) error {
 	streamMerger.Start()
 	err := cmd.Run()
 	if err != nil {
+		// force jsonConverter to flush the buffer, so we get the "fail" event when a test case panics.
 		jsonConverter.Write([]byte{marker})
 		jsonConverter.Write(bigFail)
 		jsonConverter.Write([]byte("\n"))

--- a/go/tools/bzltestutil/wrap.go
+++ b/go/tools/bzltestutil/wrap.go
@@ -141,15 +141,15 @@ func Wrap(pkg string) error {
 	cmd.Stdout = io.MultiWriter(os.Stdout, streamMerger.OutW)
 	streamMerger.Start()
 	err := cmd.Run()
+	streamMerger.ErrW.Close()
+	streamMerger.OutW.Close()
+	streamMerger.Wait()
 	if err != nil {
 		// force jsonConverter to flush the buffer, so we get the "fail" event when a test case panics.
 		jsonConverter.Write([]byte{marker})
 		jsonConverter.Write(bigFail)
 		jsonConverter.Write([]byte("\n"))
 	}
-	streamMerger.ErrW.Close()
-	streamMerger.OutW.Close()
-	streamMerger.Wait()
 	jsonConverter.Close()
 	if out, ok := os.LookupEnv("XML_OUTPUT_FILE"); ok {
 		werr := writeReport(jsonBuffer, pkg, out)

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -285,6 +285,11 @@ go_bazel_test(
     srcs = ["timeout_test.go"],
 )
 
+go_bazel_test(
+    name = "xml_panic_test",
+    srcs = ["xml_panic_test.go"],
+)
+
 # Tests using .syso files in go_binary both transitively and directly.
 go_test(
     name = "syso_transitive_test",

--- a/tests/core/go_test/xml_panic_test.go
+++ b/tests/core/go_test/xml_panic_test.go
@@ -46,7 +46,9 @@ type xmlTestCase struct {
 }
 type xmlTestSuite struct {
 	XMLName   xml.Name      `xml:"testsuite"`
+	Name    string     `xml:"name,attr"`
 	TestCases []xmlTestCase `xml:"testcase"`
+	Time      string         `xml:"time,attr"`
 }
 type xmlTestSuites struct {
 	XMLName xml.Name       `xml:"testsuites"`
@@ -80,6 +82,9 @@ func Test(t *testing.T) {
 	}
 
 	for _, suite := range suites.Suites {
+		if suite.Time == "" {
+			t.Errorf("empty time attribute for test suite %q", suite.Name)
+		}
 		for _, tc := range suite.TestCases {
 			if tc.Time == "" {
 				t.Errorf("empty time attribute for test case %q", tc.Name)

--- a/tests/core/go_test/xml_panic_test.go
+++ b/tests/core/go_test/xml_panic_test.go
@@ -1,0 +1,92 @@
+package xml_panic_test
+
+import (
+	"encoding/xml"
+	"errors"
+	"io/ioutil"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+	name = "panic_test",
+	srcs = ["panic_test.go"],
+)
+-- panic_test.go --
+package panic_test
+
+import "testing"
+
+func TestPanic(t *testing.T) {
+	panic("panic by design")
+}
+`,
+	})
+}
+
+type testError struct {
+	Message string `xml:"message,attr"`
+}
+
+type xmlTestCase struct {
+	XMLName xml.Name   `xml:"testcase"`
+	Name    string     `xml:"name,attr"`
+	Time    string     `xml:"time,attr"`
+	Error   *testError `xml:"error"`
+}
+type xmlTestSuite struct {
+	XMLName   xml.Name      `xml:"testsuite"`
+	TestCases []xmlTestCase `xml:"testcase"`
+}
+type xmlTestSuites struct {
+	XMLName xml.Name       `xml:"testsuites"`
+	Suites  []xmlTestSuite `xml:"testsuite"`
+}
+
+func Test(t *testing.T) {
+	err := bazel_testing.RunBazel("test", "//:panic_test", "--test_env=GO_TEST_WRAP_TESTV=1")
+	if err == nil {
+		t.Fatal("expected test to fail")
+	}
+	var exErr *exec.ExitError
+	if !errors.As(err, &exErr) {
+		t.Fatalf("unexpected error: %v", err)
+	} else if exErr.ExitCode() != 3 {
+		t.Fatalf("unexpected exit code %d\n%s", exErr.ExitCode(), exErr.Stderr)
+	}
+	p, err := bazel_testing.BazelOutput("info", "bazel-testlogs")
+	if err != nil {
+		t.Fatalf("could not find testlog root: %s", err)
+	}
+	path := filepath.Join(strings.TrimSpace(string(p)), "panic_test/test.xml")
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		t.Fatalf("could not read generated xml file: %s", err)
+	}
+
+	var suites xmlTestSuites
+	if err := xml.Unmarshal(b, &suites); err != nil {
+		t.Fatalf("could not unmarshall generated xml: %s", err)
+	}
+
+	for _, suite := range suites.Suites {
+		for _, tc := range suite.TestCases {
+			if tc.Time == "" {
+				t.Errorf("empty time attribute for test case %q", tc.Name)
+			}
+			if tc.Error != nil {
+				t.Errorf("unexpected error for test case %q: %s", tc.Name, tc.Error.Message)
+			}
+		}
+	}
+}


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
When rules_go runs a test that panics, it doesn't produce the final "FAIL" line, which the JSON converter relies on to flush the buffer at the end. This PR writes the "FAIL" line to the JSON converter whenever a test exits with a non-zero code to make sure the buffer is always flushed.

**Which issues(s) does this PR fix?**

Fixes #4280

**Other notes for review**
When a test fails normally, the test would produce the "FAIL" line. When this happens, the JSON converter would get two "FAIL" lines, and flush the buffer twice at the end, which is fine.

If we run a test with `go test` and it panics, the "FAIL" line is still produced. It is still a mystery why `bazel test` wouldn't produce the "FAIL" line. As @jayconrod pointed out, the test to json logic in Go is not well-designed. It may not worth fixing, but I am open to suggestions.
