### PR TITLE
fix(cgo): exclude crypto/internal/sysrand/internal/seccomp from SDK srcs

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -29,6 +29,8 @@ filegroup(
             "src/**/*_test.go",
             "src/**/testdata/**",
             "src/cmd/**",
+            # Only used by tests, cgo fails with linux before 3.17
+            "src/crypto/internal/sysrand/internal/seccomp/**",
             "src/log/slog/internal/benchmarks/**",
             "src/log/slog/internal/slogtest/**",
             "src/internal/obscuretestdata/**",


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `crypto/internal/sysrand/internal/seccomp` package fails to compile with linux kernel sources prior to 3.17. It's an internal package that is only used by unit tests, so compiling it as part of the monolithic SDK target is a waste of time anyway, so just exclude it.

**Which issues(s) does this PR fix?**

Fixes #4310