### PR TITLE
go_sdk: Pick a consistent repo name to improve cachability

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -344,11 +344,11 @@ def _go_sdk_impl(ctx):
         return None
 
 def _default_go_sdk_name(*, module, multi_version, tag_type, index, suffix = ""):
-    # Keep the version out of the repository name if possible to prevent unnecessary rebuilds when
-    # it changes.
+    # Keep the version and name of the root module out of the repository name if possible to
+    # prevent unnecessary rebuilds when it changes.
     return "{name}_{version}_{tag_type}_{index}{suffix}".format(
         # "main_" is not a valid module name and thus can't collide.
-        name = module.name or "main_",
+        name = "main_" if module.is_root else module.name,
         version = module.version if multi_version else "",
         tag_type = tag_type,
         index = index,


### PR DESCRIPTION
The SDK's repo name will be part of the builder path and as such part of every compile/linking action. Pick a generic name for the root module to allow caching these actions across modules.

This change assumes that every module other than the root module will have a name.

Fixes #4312

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Pick the same repo name for the SDK download across different root modules. This matters as every compilation/linking will be done through the builder and the repo name is part of the path to the builder. After this change the path will be consistent across different root modules.

**Which issues(s) does this PR fix?**

Fixes #4312

**Other notes for review**

This code assumes that every non-root module has a name (e.g. imported via a bazel_dep).