### PR TITLE
deps: Get repositories.bzl in sync with go.mod

### DIFF
--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -198,13 +198,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
-        sha256 = "6b0ebb2360fee569d930c1ff9e4d09de4ed982a305f81d157349e3c680765c74",
-        # cmd/protoc-gen-go-grpc/v1.5.1, from 2024-07-29
+        sha256 = "1e84df03c94d1cded8e94da7a2df162463f3be4c7a94289d85c0871f14c7b8e3",
+        # cmd/protoc-gen-go-grpc/v1.3.0, latest as of 2024-05-20
         urls = [
-            "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.5.1.zip",
-            "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.5.1.zip",
+            "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
+            "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
         ],
-        strip_prefix = "grpc-go-cmd-protoc-gen-go-grpc-v1.5.1/cmd/protoc-gen-go-grpc",
+        strip_prefix = "grpc-go-cmd-protoc-gen-go-grpc-v1.3.0/cmd/protoc-gen-go-grpc",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/grpc/cmd/protoc-gen-go-grpc -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch"),

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -125,13 +125,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_x_sys",
-        # v0.20.0, latest as of 2024-05-20
+        # v0.30.0, from 2025-01-31
         urls = [
-            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.20.0.zip",
-            "https://github.com/golang/sys/archive/refs/tags/v0.20.0.zip",
+            "https://mirror.bazel.build/github.com/golang/sys/archive/refs/tags/v0.30.0.zip",
+            "https://github.com/golang/sys/archive/refs/tags/v0.30.0.zip",
         ],
-        sha256 = "e9ad578952169036fb5023b0f53c0315d5f73146fc33d70255fa6d6edd859f84",
-        strip_prefix = "sys-0.20.0",
+        sha256 = "4acf3387a5ab61b6e2af0463491d0c6cea7a8db5f855ad4f77819f1bce93f749",
+        strip_prefix = "sys-0.30.0",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix golang.org/x/sys -go_naming_convention import_alias
             Label("//third_party:org_golang_x_sys-gazelle.patch"),
@@ -179,13 +179,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_protobuf",
-        sha256 = "39a8bbfadaa3e71f9d7741d67ee60d69db40422dc531708a777259e594d923e3",
-        # v1.33.0, latest as of 2024-04-19
+        sha256 = "87fc5518c998c350c44a0feab93b236cc10b2d184d4a8b8129b8991d4d5ca584",
+        # v1.36.3, from 2025-01-15
         urls = [
-            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.33.0.zip",
-            "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.33.0.zip",
+            "https://mirror.bazel.build/github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.36.3.zip",
+            "https://github.com/protocolbuffers/protobuf-go/archive/refs/tags/v1.36.3.zip",
         ],
-        strip_prefix = "protobuf-go-1.33.0",
+        strip_prefix = "protobuf-go-1.36.3",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/protobuf -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_protobuf-gazelle.patch"),
@@ -198,13 +198,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_grpc_cmd_protoc_gen_go_grpc",
-        sha256 = "1e84df03c94d1cded8e94da7a2df162463f3be4c7a94289d85c0871f14c7b8e3",
-        # cmd/protoc-gen-go-grpc/v1.3.0, latest as of 2024-05-20
+        sha256 = "6b0ebb2360fee569d930c1ff9e4d09de4ed982a305f81d157349e3c680765c74",
+        # cmd/protoc-gen-go-grpc/v1.5.1, from 2024-07-29
         urls = [
-            "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
-            "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.3.0.zip",
+            "https://mirror.bazel.build/github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.5.1.zip",
+            "https://github.com/grpc/grpc-go/archive/refs/tags/cmd/protoc-gen-go-grpc/v1.5.1.zip",
         ],
-        strip_prefix = "grpc-go-cmd-protoc-gen-go-grpc-v1.3.0/cmd/protoc-gen-go-grpc",
+        strip_prefix = "grpc-go-cmd-protoc-gen-go-grpc-v1.5.1/cmd/protoc-gen-go-grpc",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/grpc/cmd/protoc-gen-go-grpc -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch"),
@@ -263,13 +263,13 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "org_golang_google_genproto",
-        # main, as of 2024-05-20
+        # from 2025-01-15
         urls = [
-            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/dc85e6b867a5ebdfeaa293ddb423f00255ec921e.zip",
-            "https://github.com/googleapis/go-genproto/archive/dc85e6b867a5ebdfeaa293ddb423f00255ec921e.zip",
+            "https://mirror.bazel.build/github.com/googleapis/go-genproto/archive/1a7da9e5054f0b2e0ac1394d0a8538a3b74f6983.zip",
+            "https://github.com/googleapis/go-genproto/archive/1a7da9e5054f0b2e0ac1394d0a8538a3b74f6983.zip",
         ],
-        sha256 = "ef3c82a1e6951a7931107d00ad4fe034366903290feae82bb1a19211c86d9d2f",
-        strip_prefix = "go-genproto-dc85e6b867a5ebdfeaa293ddb423f00255ec921e",
+        sha256 = "e0123b04bc8265fb288f565c4fd867af1e846a3d20306988c6d83c05736f2e5b",
+        strip_prefix = "go-genproto-1a7da9e5054f0b2e0ac1394d0a8538a3b74f6983",
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix google.golang.org/genproto -go_naming_convention import_alias -proto disable_global
             Label("//third_party:org_golang_google_genproto-gazelle.patch"),
@@ -291,18 +291,18 @@ def go_rules_dependencies(force = False):
     _maybe(
         http_archive,
         name = "com_github_golang_mock",
-        # v1.6.0, latest as of 2024-05-20
+        # v1.7.0-rc.1, from 2022-05-12
         urls = [
-            "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.6.0.zip",
-            "https://github.com/golang/mock/archive/refs/tags/v1.6.0.zip",
+            "https://mirror.bazel.build/github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
+            "https://github.com/golang/mock/archive/refs/tags/v1.7.0-rc.1.zip",
         ],
         patches = [
             # releaser:patch-cmd gazelle -repo_root . -go_prefix github.com/golang/mock -go_naming_convention import_alias
             Label("//third_party:com_github_golang_mock-gazelle.patch"),
         ],
         patch_args = ["-p1"],
-        sha256 = "604d9ab25b07d60c1b8ba6d3ea2e66873138edeed2e561c5358de804ea421a0e",
-        strip_prefix = "mock-1.6.0",
+        sha256 = "5359c78b0c1649cf7beb3b48ff8b1d1aaf0243b22ea4789aba94805280075d8e",
+        strip_prefix = "mock-1.7.0-rc.1",
     )
 
     # This may be overridden by go_register_toolchains, but it's not mandatory

--- a/third_party/com_github_golang_mock-gazelle.patch
+++ b/third_party/com_github_golang_mock-gazelle.patch
@@ -1,7 +1,7 @@
 diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
 --- a/gomock/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/gomock/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,34 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -10,6 +10,7 @@ diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
 +        "call.go",
 +        "callset.go",
 +        "controller.go",
++        "doc.go",
 +        "matchers.go",
 +    ],
 +    importpath = "github.com/golang/mock/gomock",
@@ -27,8 +28,6 @@ diff -urN a/gomock/BUILD.bazel b/gomock/BUILD.bazel
 +    srcs = [
 +        "call_test.go",
 +        "callset_test.go",
-+        "controller_113_test.go",
-+        "controller_114_test.go",
 +        "controller_test.go",
 +        "example_test.go",
 +        "matchers_test.go",
@@ -59,17 +58,18 @@ diff -urN a/gomock/internal/mock_gomock/BUILD.bazel b/gomock/internal/mock_gomoc
 diff -urN a/mockgen/BUILD.bazel b/mockgen/BUILD.bazel
 --- a/mockgen/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
 +    name = "mockgen_lib",
 +    srcs = [
++        "generic_go118.go",
++        "generic_notgo118.go",
 +        "mockgen.go",
 +        "parse.go",
 +        "reflect.go",
-+        "version.1.11.go",
-+        "version.1.12.go",
++        "version.go",
 +    ],
 +    importpath = "github.com/golang/mock/mockgen",
 +    visibility = ["//visibility:private"],
@@ -355,10 +355,72 @@ diff -urN a/mockgen/internal/tests/generated_identifier_conflict/BUILD.bazel b/m
 +    embed = [":generated_identifier_conflict"],
 +    deps = ["//gomock"],
 +)
+diff -urN a/mockgen/internal/tests/generics/BUILD.bazel b/mockgen/internal/tests/generics/BUILD.bazel
+--- a/mockgen/internal/tests/generics/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/mockgen/internal/tests/generics/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "generics",
++    srcs = [
++        "external.go",
++        "generics.go",
++    ],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/generics",
++    visibility = ["//mockgen:__subpackages__"],
++    deps = [
++        "//mockgen/internal/tests/generics/other",
++        "@org_golang_x_exp//constraints:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":generics",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/generics/other/BUILD.bazel b/mockgen/internal/tests/generics/other/BUILD.bazel
+--- a/mockgen/internal/tests/generics/other/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/mockgen/internal/tests/generics/other/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "other",
++    srcs = ["other.go"],
++    importpath = "github.com/golang/mock/mockgen/internal/tests/generics/other",
++    visibility = ["//mockgen:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":other",
++    visibility = ["//mockgen:__subpackages__"],
++)
+diff -urN a/mockgen/internal/tests/generics/source/BUILD.bazel b/mockgen/internal/tests/generics/source/BUILD.bazel
+--- a/mockgen/internal/tests/generics/source/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/mockgen/internal/tests/generics/source/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "source_test",
++    srcs = [
++        "mock_external_test.go",
++        "mock_generics_test.go",
++    ],
++    deps = [
++        "//gomock",
++        "//mockgen/internal/tests/generics",
++        "//mockgen/internal/tests/generics/other",
++        "@org_golang_x_exp//constraints:go_default_library",
++    ],
++)
 diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel
 --- a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/mockgen/internal/tests/import_embedded_interface/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,36 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -366,6 +428,7 @@ diff -urN a/mockgen/internal/tests/import_embedded_interface/BUILD.bazel b/mockg
 +    srcs = [
 +        "bugreport.go",
 +        "bugreport_mock.go",
++        "foo.go",
 +        "net.go",
 +        "net_mock.go",
 +    ],

--- a/third_party/org_golang_google_genproto-gazelle.patch
+++ b/third_party/org_golang_google_genproto-gazelle.patch
@@ -370,6 +370,28 @@ diff -urN a/googleapis/analytics/management/v1alpha/BUILD.bazel b/googleapis/ana
 +    actual = ":v1alpha",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/api/BUILD.bazel b/googleapis/api/BUILD.bazel
+--- a/googleapis/api/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/api/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "api",
++    srcs = ["launch_stage.pb.go"],
++    importpath = "google.golang.org/genproto/googleapis/api",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":api",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/api/annotations/BUILD.bazel b/googleapis/api/annotations/BUILD.bazel
 --- a/googleapis/api/annotations/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/api/annotations/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -423,28 +445,6 @@ diff -urN a/googleapis/api/apikeys/v2/BUILD.bazel b/googleapis/api/apikeys/v2/BU
 +alias(
 +    name = "go_default_library",
 +    actual = ":apikeys",
-+    visibility = ["//visibility:public"],
-+)
-diff -urN a/googleapis/api/BUILD.bazel b/googleapis/api/BUILD.bazel
---- a/googleapis/api/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/googleapis/api/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "api",
-+    srcs = ["launch_stage.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/api",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":api",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/api/configchange/BUILD.bazel b/googleapis/api/configchange/BUILD.bazel
@@ -1512,35 +1512,17 @@ diff -urN a/googleapis/bigtable/admin/table/v1/BUILD.bazel b/googleapis/bigtable
 diff -urN a/googleapis/bigtable/admin/v2/BUILD.bazel b/googleapis/bigtable/admin/v2/BUILD.bazel
 --- a/googleapis/bigtable/admin/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/admin/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "admin",
-+    srcs = [
-+        "bigtable_instance_admin.pb.go",
-+        "bigtable_table_admin.pb.go",
-+        "common.pb.go",
-+        "instance.pb.go",
-+        "table.pb.go",
-+        "types.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/bigtable/admin/v2",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/rpc/status",
-+        "@com_google_cloud_go_iam//apiv1/iampb:go_default_library",
-+        "@com_google_cloud_go_longrunning//autogen/longrunningpb:go_default_library",
++        "@com_google_cloud_go_bigtable//admin/apiv2/adminpb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/emptypb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/fieldmaskpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
 +    ],
 +)
 +
@@ -1585,31 +1567,17 @@ diff -urN a/googleapis/bigtable/v1/BUILD.bazel b/googleapis/bigtable/v1/BUILD.ba
 diff -urN a/googleapis/bigtable/v2/BUILD.bazel b/googleapis/bigtable/v2/BUILD.bazel
 --- a/googleapis/bigtable/v2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/bigtable/v2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "bigtable",
-+    srcs = [
-+        "bigtable.pb.go",
-+        "data.pb.go",
-+        "feature_flags.pb.go",
-+        "request_stats.pb.go",
-+        "response_params.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/bigtable/v2",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/rpc/status",
++        "@com_google_cloud_go_bigtable//apiv2/bigtablepb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
 +    ],
 +)
 +
@@ -3614,7 +3582,7 @@ diff -urN a/googleapis/cloud/common/BUILD.bazel b/googleapis/cloud/common/BUILD.
 diff -urN a/googleapis/cloud/compute/v1/BUILD.bazel b/googleapis/cloud/compute/v1/BUILD.bazel
 --- a/googleapis/cloud/compute/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/compute/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -3622,10 +3590,7 @@ diff -urN a/googleapis/cloud/compute/v1/BUILD.bazel b/googleapis/cloud/compute/v
 +    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/compute/v1",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_cloud_go_compute//apiv1/computepb:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+    ],
++    deps = ["@com_google_cloud_go_compute//apiv1/computepb:go_default_library"],
 +)
 +
 +alias(
@@ -3814,7 +3779,7 @@ diff -urN a/googleapis/cloud/datacatalog/v1beta1/BUILD.bazel b/googleapis/cloud/
 diff -urN a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel b/googleapis/cloud/dataform/v1alpha2/BUILD.bazel
 --- a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/cloud/dataform/v1alpha2/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,15 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -3822,10 +3787,7 @@ diff -urN a/googleapis/cloud/dataform/v1alpha2/BUILD.bazel b/googleapis/cloud/da
 +    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/cloud/dataform/v1alpha2",
 +    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_cloud_go_dataform//apiv1alpha2/dataformpb:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+    ],
++    deps = ["@org_golang_google_grpc//:go_default_library"],
 +)
 +
 +alias(
@@ -9153,32 +9115,17 @@ diff -urN a/googleapis/datastore/admin/v1beta1/BUILD.bazel b/googleapis/datastor
 diff -urN a/googleapis/datastore/v1/BUILD.bazel b/googleapis/datastore/v1/BUILD.bazel
 --- a/googleapis/datastore/v1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/datastore/v1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "datastore",
-+    srcs = [
-+        "aggregation_result.pb.go",
-+        "datastore.pb.go",
-+        "entity.pb.go",
-+        "query.pb.go",
-+        "query_profile.pb.go",
-+    ],
++    srcs = ["alias.go"],
 +    importpath = "google.golang.org/genproto/googleapis/datastore/v1",
 +    visibility = ["//visibility:public"],
 +    deps = [
-+        "//googleapis/api/annotations",
-+        "//googleapis/type/latlng",
++        "@com_google_cloud_go_datastore//apiv1/datastorepb:go_default_library",
 +        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//codes:go_default_library",
-+        "@org_golang_google_grpc//status:go_default_library",
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/timestamppb:go_default_library",
-+        "@org_golang_google_protobuf//types/known/wrapperspb:go_default_library",
 +    ],
 +)
 +
@@ -9466,6 +9413,28 @@ diff -urN a/googleapis/devtools/containeranalysis/v1/BUILD.bazel b/googleapis/de
 +    actual = ":containeranalysis",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel
+--- a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,18 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "v1beta1",
++    srcs = ["alias.go"],
++    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@com_google_cloud_go_containeranalysis//apiv1beta1/containeranalysispb:go_default_library",
++        "@org_golang_google_grpc//:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":v1beta1",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel
 --- a/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/devtools/containeranalysis/v1beta1/attestation/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -9510,28 +9479,6 @@ diff -urN a/googleapis/devtools/containeranalysis/v1beta1/build/BUILD.bazel b/go
 +alias(
 +    name = "go_default_library",
 +    actual = ":build",
-+    visibility = ["//visibility:public"],
-+)
-diff -urN a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel
---- a/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/googleapis/devtools/containeranalysis/v1beta1/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "v1beta1",
-+    srcs = ["alias.go"],
-+    importpath = "google.golang.org/genproto/googleapis/devtools/containeranalysis/v1beta1",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@com_google_cloud_go_containeranalysis//apiv1beta1/containeranalysispb:go_default_library",
-+        "@org_golang_google_grpc//:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":v1beta1",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel b/googleapis/devtools/containeranalysis/v1beta1/common/BUILD.bazel
@@ -11174,6 +11121,29 @@ diff -urN a/googleapis/rpc/code/BUILD.bazel b/googleapis/rpc/code/BUILD.bazel
 +    actual = ":code",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/googleapis/rpc/context/BUILD.bazel b/googleapis/rpc/context/BUILD.bazel
+--- a/googleapis/rpc/context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/rpc/context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "context",
++    srcs = ["audit_context.pb.go"],
++    importpath = "google.golang.org/genproto/googleapis/rpc/context",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":context",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/googleapis/rpc/context/attribute_context/BUILD.bazel b/googleapis/rpc/context/attribute_context/BUILD.bazel
 --- a/googleapis/rpc/context/attribute_context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/rpc/context/attribute_context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -11198,29 +11168,6 @@ diff -urN a/googleapis/rpc/context/attribute_context/BUILD.bazel b/googleapis/rp
 +alias(
 +    name = "go_default_library",
 +    actual = ":attribute_context",
-+    visibility = ["//visibility:public"],
-+)
-diff -urN a/googleapis/rpc/context/BUILD.bazel b/googleapis/rpc/context/BUILD.bazel
---- a/googleapis/rpc/context/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/googleapis/rpc/context/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "context",
-+    srcs = ["audit_context.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/rpc/context",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/structpb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":context",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/rpc/errdetails/BUILD.bazel b/googleapis/rpc/errdetails/BUILD.bazel
@@ -11645,29 +11592,6 @@ diff -urN a/googleapis/type/date_range/BUILD.bazel b/googleapis/type/date_range/
 +    actual = ":date_range",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/googleapis/type/datetime/BUILD.bazel b/googleapis/type/datetime/BUILD.bazel
---- a/googleapis/type/datetime/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/googleapis/type/datetime/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,19 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "datetime",
-+    srcs = ["datetime.pb.go"],
-+    importpath = "google.golang.org/genproto/googleapis/type/datetime",
-+    visibility = ["//visibility:public"],
-+    deps = [
-+        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
-+        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
-+        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
-+    ],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":datetime",
-+    visibility = ["//visibility:public"],
-+)
 diff -urN a/googleapis/type/date_time_range/BUILD.bazel b/googleapis/type/date_time_range/BUILD.bazel
 --- a/googleapis/type/date_time_range/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/googleapis/type/date_time_range/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -11689,6 +11613,29 @@ diff -urN a/googleapis/type/date_time_range/BUILD.bazel b/googleapis/type/date_t
 +alias(
 +    name = "go_default_library",
 +    actual = ":date_time_range",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/googleapis/type/datetime/BUILD.bazel b/googleapis/type/datetime/BUILD.bazel
+--- a/googleapis/type/datetime/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/googleapis/type/datetime/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "datetime",
++    srcs = ["datetime.pb.go"],
++    importpath = "google.golang.org/genproto/googleapis/type/datetime",
++    visibility = ["//visibility:public"],
++    deps = [
++        "@org_golang_google_protobuf//reflect/protoreflect:go_default_library",
++        "@org_golang_google_protobuf//runtime/protoimpl:go_default_library",
++        "@org_golang_google_protobuf//types/known/durationpb:go_default_library",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":datetime",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/googleapis/type/dayofweek/BUILD.bazel b/googleapis/type/dayofweek/BUILD.bazel
@@ -12006,6 +11953,24 @@ diff -urN a/googleapis/watcher/v1/BUILD.bazel b/googleapis/watcher/v1/BUILD.baze
 +    actual = ":watcher",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/internal/BUILD.bazel b/internal/BUILD.bazel
+--- a/internal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,14 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "internal",
++    srcs = ["doc.go"],
++    importpath = "google.golang.org/genproto/internal",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":internal",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN a/internal/actions/cmd/changefinder/BUILD.bazel b/internal/actions/cmd/changefinder/BUILD.bazel
 --- a/internal/actions/cmd/changefinder/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/actions/cmd/changefinder/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -12040,24 +12005,6 @@ diff -urN a/internal/actions/logg/BUILD.bazel b/internal/actions/logg/BUILD.baze
 +alias(
 +    name = "go_default_library",
 +    actual = ":logg",
-+    visibility = ["//:__subpackages__"],
-+)
-diff -urN a/internal/BUILD.bazel b/internal/BUILD.bazel
---- a/internal/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/internal/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,14 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library")
-+
-+go_library(
-+    name = "internal",
-+    srcs = ["doc.go"],
-+    importpath = "google.golang.org/genproto/internal",
-+    visibility = ["//:__subpackages__"],
-+)
-+
-+alias(
-+    name = "go_default_library",
-+    actual = ":internal",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/protobuf/api/BUILD.bazel b/protobuf/api/BUILD.bazel

--- a/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
+++ b/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
@@ -1,8 +1,8 @@
 diff -urN a/BUILD.bazel b/BUILD.bazel
 --- a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+@@ -0,0 +1,23 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
 +    name = "protoc-gen-go-grpc_lib",
@@ -24,13 +24,4 @@ diff -urN a/BUILD.bazel b/BUILD.bazel
 +    name = "protoc-gen-go-grpc",
 +    embed = [":protoc-gen-go-grpc_lib"],
 +    visibility = ["//visibility:public"],
-+)
-+
-+go_test(
-+    name = "protoc-gen-go-grpc_test",
-+    srcs = ["unimpl_test.go"],
-+    deps = [
-+        "@org_golang_google_grpc//:go_default_library",
-+        "@org_golang_google_grpc//interop/grpc_testing:go_default_library",
-+    ],
 +)

--- a/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
+++ b/third_party/org_golang_google_grpc_cmd_protoc_gen_go_grpc.patch
@@ -1,8 +1,8 @@
 diff -urN a/BUILD.bazel b/BUILD.bazel
 --- a/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,23 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+@@ -0,0 +1,32 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
 +    name = "protoc-gen-go-grpc_lib",
@@ -24,4 +24,13 @@ diff -urN a/BUILD.bazel b/BUILD.bazel
 +    name = "protoc-gen-go-grpc",
 +    embed = [":protoc-gen-go-grpc_lib"],
 +    visibility = ["//visibility:public"],
++)
++
++go_test(
++    name = "protoc-gen-go-grpc_test",
++    srcs = ["unimpl_test.go"],
++    deps = [
++        "@org_golang_google_grpc//:go_default_library",
++        "@org_golang_google_grpc//interop/grpc_testing:go_default_library",
++    ],
 +)

--- a/third_party/org_golang_google_protobuf-gazelle.patch
+++ b/third_party/org_golang_google_protobuf-gazelle.patch
@@ -12,7 +12,7 @@ diff -urN a/BUILD.bazel b/BUILD.bazel
 diff -urN a/cmd/protoc-gen-go/BUILD.bazel b/cmd/protoc-gen-go/BUILD.bazel
 --- a/cmd/protoc-gen-go/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,38 @@
+@@ -0,0 +1,40 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 +
 +go_library(
@@ -37,10 +37,12 @@ diff -urN a/cmd/protoc-gen-go/BUILD.bazel b/cmd/protoc-gen-go/BUILD.bazel
 +    name = "protoc-gen-go_test",
 +    srcs = [
 +        "annotation_test.go",
++        "enumprefix_test.go",
 +        "retention_test.go",
 +    ],
 +    embed = [":protoc-gen-go_lib"],
 +    deps = [
++        "//cmd/protoc-gen-go/testdata/enumprefix",
 +        "//cmd/protoc-gen-go/testdata/retention",
 +        "//encoding/prototext",
 +        "//internal/genid",
@@ -51,17 +53,49 @@ diff -urN a/cmd/protoc-gen-go/BUILD.bazel b/cmd/protoc-gen-go/BUILD.bazel
 +        "@com_github_google_go_cmp//cmp:go_default_library",
 +    ],
 +)
+diff -urN a/cmd/protoc-gen-go/builder_test/BUILD.bazel b/cmd/protoc-gen-go/builder_test/BUILD.bazel
+--- a/cmd/protoc-gen-go/builder_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/builder_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,11 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "builder_test_test",
++    srcs = ["builder_test.go"],
++    deps = [
++        "//internal/testprotos/testeditions/testeditions_hybrid",
++        "//internal/testprotos/testeditions/testeditions_opaque",
++        "//proto",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/descriptor_test/BUILD.bazel b/cmd/protoc-gen-go/descriptor_test/BUILD.bazel
+--- a/cmd/protoc-gen-go/descriptor_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/descriptor_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,11 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "descriptor_test_test",
++    srcs = ["descriptor_test.go"],
++    deps = [
++        "//internal/testprotos/test",
++        "//internal/testprotos/testeditions/testeditions_hybrid",
++        "//internal/testprotos/testeditions/testeditions_opaque",
++    ],
++)
 diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/internal_gengo/BUILD.bazel
 --- a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/internal_gengo/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,38 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "internal_gengo",
 +    srcs = [
 +        "init.go",
++        "init_opaque.go",
 +        "main.go",
++        "opaque.go",
 +        "reflect.go",
 +        "well_known_types.go",
 +    ],
@@ -70,6 +104,7 @@ diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/int
 +    deps = [
 +        "//compiler/protogen",
 +        "//encoding/protowire",
++        "//internal/editionssupport",
 +        "//internal/encoding/tag",
 +        "//internal/filedesc",
 +        "//internal/genid",
@@ -80,6 +115,7 @@ diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/int
 +        "//reflect/protoreflect",
 +        "//runtime/protoimpl",
 +        "//types/descriptorpb",
++        "//types/gofeaturespb",
 +        "//types/pluginpb",
 +    ],
 +)
@@ -88,6 +124,100 @@ diff -urN a/cmd/protoc-gen-go/internal_gengo/BUILD.bazel b/cmd/protoc-gen-go/int
 +    name = "go_default_library",
 +    actual = ":internal_gengo",
 +    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/name_clash_test/BUILD.bazel b/cmd/protoc-gen-go/name_clash_test/BUILD.bazel
+--- a/cmd/protoc-gen-go/name_clash_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/name_clash_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,24 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "name_clash_test_test",
++    srcs = [
++        "name_clash_proto3_test.go",
++        "name_clash_test.go",
++    ],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3",
++        "//compiler/protogen",
++        "//internal/genid",
++        "//proto",
++        "//reflect/protodesc",
++        "//types/descriptorpb",
++        "//types/gofeaturespb",
++        "//types/pluginpb",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/opaque_default_test/BUILD.bazel b/cmd/protoc-gen-go/opaque_default_test/BUILD.bazel
+--- a/cmd/protoc-gen-go/opaque_default_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/opaque_default_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,10 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "opaque_default_test_test",
++    srcs = ["opaque_default_test.go"],
++    deps = [
++        "//internal/testprotos/enums/enums_opaque",
++        "//internal/testprotos/testeditions/testeditions_opaque",
++    ],
++)
+diff -urN a/cmd/protoc-gen-go/opaque_map_test/BUILD.bazel b/cmd/protoc-gen-go/opaque_map_test/BUILD.bazel
+--- a/cmd/protoc-gen-go/opaque_map_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/opaque_map_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,7 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "opaque_map_test_test",
++    srcs = ["opaque_map_test.go"],
++    deps = ["//internal/testprotos/testeditions/testeditions_opaque"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/BUILD.bazel b/cmd/protoc-gen-go/testdata/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,37 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "testdata_test",
++    srcs = [
++        "gen_test.go",
++        "registry_test.go",
++    ],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/annotations",
++        "//cmd/protoc-gen-go/testdata/comments",
++        "//cmd/protoc-gen-go/testdata/enumprefix",
++        "//cmd/protoc-gen-go/testdata/extensions/base",
++        "//cmd/protoc-gen-go/testdata/extensions/ext",
++        "//cmd/protoc-gen-go/testdata/extensions/extra",
++        "//cmd/protoc-gen-go/testdata/extensions/proto3",
++        "//cmd/protoc-gen-go/testdata/fieldnames",
++        "//cmd/protoc-gen-go/testdata/import_public",
++        "//cmd/protoc-gen-go/testdata/import_public/sub",
++        "//cmd/protoc-gen-go/testdata/import_public/sub2",
++        "//cmd/protoc-gen-go/testdata/imports",
++        "//cmd/protoc-gen-go/testdata/imports/fmt",
++        "//cmd/protoc-gen-go/testdata/imports/test_a_1",
++        "//cmd/protoc-gen-go/testdata/imports/test_a_2",
++        "//cmd/protoc-gen-go/testdata/imports/test_b_1",
++        "//cmd/protoc-gen-go/testdata/issue780_oneof_conflict",
++        "//cmd/protoc-gen-go/testdata/nameclash",
++        "//cmd/protoc-gen-go/testdata/nopackage",
++        "//cmd/protoc-gen-go/testdata/proto2",
++        "//cmd/protoc-gen-go/testdata/proto3",
++        "//cmd/protoc-gen-go/testdata/protoeditions",
++        "//cmd/protoc-gen-go/testdata/retention",
++        "//internal/filedesc",
++        "//reflect/protoreflect",
++        "//reflect/protoregistry",
++    ],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel b/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel
 --- a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -112,45 +242,6 @@ diff -urN a/cmd/protoc-gen-go/testdata/annotations/BUILD.bazel b/cmd/protoc-gen-
 +    actual = ":annotations",
 +    visibility = ["//visibility:public"],
 +)
-diff -urN a/cmd/protoc-gen-go/testdata/BUILD.bazel b/cmd/protoc-gen-go/testdata/BUILD.bazel
---- a/cmd/protoc-gen-go/testdata/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/cmd/protoc-gen-go/testdata/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,35 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_test")
-+
-+go_test(
-+    name = "testdata_test",
-+    srcs = [
-+        "gen_test.go",
-+        "registry_test.go",
-+    ],
-+    deps = [
-+        "//cmd/protoc-gen-go/testdata/annotations",
-+        "//cmd/protoc-gen-go/testdata/comments",
-+        "//cmd/protoc-gen-go/testdata/extensions/base",
-+        "//cmd/protoc-gen-go/testdata/extensions/ext",
-+        "//cmd/protoc-gen-go/testdata/extensions/extra",
-+        "//cmd/protoc-gen-go/testdata/extensions/proto3",
-+        "//cmd/protoc-gen-go/testdata/fieldnames",
-+        "//cmd/protoc-gen-go/testdata/import_public",
-+        "//cmd/protoc-gen-go/testdata/import_public/sub",
-+        "//cmd/protoc-gen-go/testdata/import_public/sub2",
-+        "//cmd/protoc-gen-go/testdata/imports",
-+        "//cmd/protoc-gen-go/testdata/imports/fmt",
-+        "//cmd/protoc-gen-go/testdata/imports/test_a_1",
-+        "//cmd/protoc-gen-go/testdata/imports/test_a_2",
-+        "//cmd/protoc-gen-go/testdata/imports/test_b_1",
-+        "//cmd/protoc-gen-go/testdata/issue780_oneof_conflict",
-+        "//cmd/protoc-gen-go/testdata/nopackage",
-+        "//cmd/protoc-gen-go/testdata/proto2",
-+        "//cmd/protoc-gen-go/testdata/proto3",
-+        "//cmd/protoc-gen-go/testdata/protoeditions",
-+        "//cmd/protoc-gen-go/testdata/retention",
-+        "//internal/filedesc",
-+        "//reflect/protoreflect",
-+        "//reflect/protoregistry",
-+    ],
-+)
 diff -urN a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel b/cmd/protoc-gen-go/testdata/comments/BUILD.bazel
 --- a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/comments/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -174,6 +265,29 @@ diff -urN a/cmd/protoc-gen-go/testdata/comments/BUILD.bazel b/cmd/protoc-gen-go/
 +alias(
 +    name = "go_default_library",
 +    actual = ":comments",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/enumprefix/BUILD.bazel b/cmd/protoc-gen-go/testdata/enumprefix/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/enumprefix/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/enumprefix/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "enumprefix",
++    srcs = ["enumprefix.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/enumprefix",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":enumprefix",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel b/cmd/protoc-gen-go/testdata/extensions/base/BUILD.bazel
@@ -514,6 +628,170 @@ diff -urN a/cmd/protoc-gen-go/testdata/issue780_oneof_conflict/BUILD.bazel b/cmd
 +    actual = ":issue780_oneof_conflict",
 +    visibility = ["//visibility:public"],
 +)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "nameclash",
++    srcs = ["nameclash.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open",
++        "//cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":nameclash",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test_name_clash_hybrid",
++    srcs = ["test_name_clash_hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_name_clash_hybrid",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test_name_clash_hybrid3",
++    srcs = ["test_name_clash_hybrid3.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_hybrid3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_name_clash_hybrid3",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test_name_clash_opaque",
++    srcs = ["test_name_clash_opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_name_clash_opaque",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test_name_clash_opaque3",
++    srcs = ["test_name_clash_opaque3.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_opaque3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_name_clash_opaque3",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test_name_clash_open",
++    srcs = ["test_name_clash_open.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_name_clash_open",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3/BUILD.bazel b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3/BUILD.bazel
+--- a/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test_name_clash_open3",
++    srcs = ["test_name_clash_open3.pb.go"],
++    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/nameclash/test_name_clash_open3",
++    visibility = ["//visibility:public"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test_name_clash_open3",
++    visibility = ["//visibility:public"],
++)
 diff -urN a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel b/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel
 --- a/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/nopackage/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -591,7 +869,7 @@ diff -urN a/cmd/protoc-gen-go/testdata/proto3/BUILD.bazel b/cmd/protoc-gen-go/te
 diff -urN a/cmd/protoc-gen-go/testdata/protoeditions/BUILD.bazel b/cmd/protoc-gen-go/testdata/protoeditions/BUILD.bazel
 --- a/cmd/protoc-gen-go/testdata/protoeditions/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cmd/protoc-gen-go/testdata/protoeditions/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,25 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -599,6 +877,8 @@ diff -urN a/cmd/protoc-gen-go/testdata/protoeditions/BUILD.bazel b/cmd/protoc-ge
 +    srcs = [
 +        "enum.pb.go",
 +        "fields.pb.go",
++        "legacy_enum.pb.go",
++        "maps_and_delimited.pb.go",
 +        "nested_messages.pb.go",
 +    ],
 +    importpath = "google.golang.org/protobuf/cmd/protoc-gen-go/testdata/protoeditions",
@@ -644,16 +924,21 @@ diff -urN a/cmd/protoc-gen-go/testdata/retention/BUILD.bazel b/cmd/protoc-gen-go
 diff -urN a/compiler/protogen/BUILD.bazel b/compiler/protogen/BUILD.bazel
 --- a/compiler/protogen/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/compiler/protogen/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,47 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "protogen",
-+    srcs = ["protogen.go"],
++    srcs = [
++        "protogen.go",
++        "protogen_apilevel.go",
++        "protogen_opaque.go",
++    ],
 +    importpath = "google.golang.org/protobuf/compiler/protogen",
 +    visibility = ["//visibility:public"],
 +    deps = [
 +        "//encoding/prototext",
++        "//internal/filedesc",
 +        "//internal/genid",
 +        "//internal/strs",
 +        "//proto",
@@ -662,6 +947,7 @@ diff -urN a/compiler/protogen/BUILD.bazel b/compiler/protogen/BUILD.bazel
 +        "//reflect/protoregistry",
 +        "//types/descriptorpb",
 +        "//types/dynamicpb",
++        "//types/gofeaturespb",
 +        "//types/pluginpb",
 +    ],
 +)
@@ -814,7 +1100,7 @@ diff -urN a/encoding/protojson/BUILD.bazel b/encoding/protojson/BUILD.bazel
 diff -urN a/encoding/prototext/BUILD.bazel b/encoding/prototext/BUILD.bazel
 --- a/encoding/prototext/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/encoding/prototext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,66 @@
+@@ -0,0 +1,70 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -856,17 +1142,21 @@ diff -urN a/encoding/prototext/BUILD.bazel b/encoding/prototext/BUILD.bazel
 +        "encode_test.go",
 +        "fuzz_test.go",
 +        "other_test.go",
++        "testmessages_opaque_test.go",
++        "testmessages_test.go",
 +    ],
 +    deps = [
 +        ":prototext",
 +        "//internal/detrand",
 +        "//internal/flags",
++        "//internal/protobuild",
 +        "//internal/testprotos/editionsfuzztest",
 +        "//internal/testprotos/test",
 +        "//internal/testprotos/test/weak1",
 +        "//internal/testprotos/textpb2",
 +        "//internal/testprotos/textpb3",
 +        "//internal/testprotos/textpbeditions",
++        "//internal/testprotos/textpbeditions/textpbeditions_opaque",
 +        "//proto",
 +        "//reflect/protoreflect",
 +        "//reflect/protoregistry",
@@ -987,7 +1277,7 @@ diff -urN a/internal/cmd/generate-protos/BUILD.bazel b/internal/cmd/generate-pro
 +        "//cmd/protoc-gen-go/internal_gengo",
 +        "//compiler/protogen",
 +        "//internal/detrand",
-+        "//reflect/protodesc",
++        "//internal/editionssupport",
 +    ],
 +)
 +
@@ -999,13 +1289,14 @@ diff -urN a/internal/cmd/generate-protos/BUILD.bazel b/internal/cmd/generate-pro
 diff -urN a/internal/cmd/generate-types/BUILD.bazel b/internal/cmd/generate-types/BUILD.bazel
 --- a/internal/cmd/generate-types/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/cmd/generate-types/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,18 @@
+@@ -0,0 +1,19 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 +
 +go_library(
 +    name = "generate-types_lib",
 +    srcs = [
 +        "impl.go",
++        "impl_opaque.go",
 +        "main.go",
 +        "proto.go",
 +    ],
@@ -1060,7 +1351,7 @@ diff -urN a/internal/cmd/pbdump/BUILD.bazel b/internal/cmd/pbdump/BUILD.bazel
 diff -urN a/internal/conformance/BUILD.bazel b/internal/conformance/BUILD.bazel
 --- a/internal/conformance/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/conformance/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,13 @@
+@@ -0,0 +1,14 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_test")
 +
 +go_test(
@@ -1071,6 +1362,7 @@ diff -urN a/internal/conformance/BUILD.bazel b/internal/conformance/BUILD.bazel
 +        "//encoding/prototext",
 +        "//internal/testprotos/conformance",
 +        "//internal/testprotos/conformance/editions",
++        "//internal/testprotos/conformance/editionsmigration",
 +        "//proto",
 +    ],
 +)
@@ -1167,6 +1459,25 @@ diff -urN a/internal/editiondefaults/BUILD.bazel b/internal/editiondefaults/BUIL
 +alias(
 +    name = "go_default_library",
 +    actual = ":editiondefaults",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/editionssupport/BUILD.bazel b/internal/editionssupport/BUILD.bazel
+--- a/internal/editionssupport/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/editionssupport/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "editionssupport",
++    srcs = ["editions.go"],
++    importpath = "google.golang.org/protobuf/internal/editionssupport",
++    visibility = ["//:__subpackages__"],
++    deps = ["//types/descriptorpb"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":editionssupport",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/encoding/defval/BUILD.bazel b/internal/encoding/defval/BUILD.bazel
@@ -1353,16 +1664,12 @@ diff -urN a/internal/encoding/text/BUILD.bazel b/internal/encoding/text/BUILD.ba
 diff -urN a/internal/errors/BUILD.bazel b/internal/errors/BUILD.bazel
 --- a/internal/errors/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/errors/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "errors",
-+    srcs = [
-+        "errors.go",
-+        "is_go112.go",
-+        "is_go113.go",
-+    ],
++    srcs = ["errors.go"],
 +    importpath = "google.golang.org/protobuf/internal/errors",
 +    visibility = ["//:__subpackages__"],
 +    deps = ["//internal/detrand"],
@@ -1599,7 +1906,7 @@ diff -urN a/internal/fuzztest/BUILD.bazel b/internal/fuzztest/BUILD.bazel
 diff -urN a/internal/genid/BUILD.bazel b/internal/genid/BUILD.bazel
 --- a/internal/genid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/genid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,33 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -1615,6 +1922,7 @@ diff -urN a/internal/genid/BUILD.bazel b/internal/genid/BUILD.bazel
 +        "go_features_gen.go",
 +        "goname.go",
 +        "map_entry.go",
++        "name.go",
 +        "source_context_gen.go",
 +        "struct_gen.go",
 +        "timestamp_gen.go",
@@ -1635,21 +1943,24 @@ diff -urN a/internal/genid/BUILD.bazel b/internal/genid/BUILD.bazel
 diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 --- a/internal/impl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/impl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,111 @@
+@@ -0,0 +1,130 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "impl",
 +    srcs = [
 +        "api_export.go",
++        "api_export_opaque.go",
++        "bitmap.go",
++        "bitmap_race.go",
 +        "checkinit.go",
 +        "codec_extension.go",
 +        "codec_field.go",
++        "codec_field_opaque.go",
 +        "codec_gen.go",
 +        "codec_map.go",
-+        "codec_map_go111.go",
-+        "codec_map_go112.go",
 +        "codec_message.go",
++        "codec_message_opaque.go",
 +        "codec_messageset.go",
 +        "codec_tables.go",
 +        "codec_unsafe.go",
@@ -1659,7 +1970,9 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +        "decode.go",
 +        "encode.go",
 +        "enum.go",
++        "equal.go",
 +        "extension.go",
++        "lazy.go",
 +        "legacy_enum.go",
 +        "legacy_export.go",
 +        "legacy_extension.go",
@@ -1668,10 +1981,15 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +        "merge.go",
 +        "merge_gen.go",
 +        "message.go",
++        "message_opaque.go",
++        "message_opaque_gen.go",
 +        "message_reflect.go",
 +        "message_reflect_field.go",
++        "message_reflect_field_gen.go",
 +        "message_reflect_gen.go",
 +        "pointer_unsafe.go",
++        "pointer_unsafe_opaque.go",
++        "presence.go",
 +        "validate.go",
 +        "weak.go",
 +    ],
@@ -1690,6 +2008,7 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +        "//internal/genid",
 +        "//internal/order",
 +        "//internal/pragma",
++        "//internal/protolazy",
 +        "//internal/strs",
 +        "//proto",
 +        "//reflect/protoreflect",
@@ -1709,6 +2028,9 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +    srcs = [
 +        "enum_test.go",
 +        "extension_test.go",
++        "lazy_buffersharing_test.go",
++        "lazy_field_normalized_test.go",
++        "lazy_normalized_test.go",
 +        "lazy_test.go",
 +        "legacy_aberrant_test.go",
 +        "legacy_export_test.go",
@@ -1719,9 +2041,12 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +    embed = [":impl"],
 +    deps = [
 +        "//encoding/prototext",
++        "//encoding/protowire",
++        "//internal/errors",
 +        "//internal/flags",
 +        "//internal/pragma",
 +        "//internal/protobuild",
++        "//internal/testprotos/lazy",
 +        "//internal/testprotos/legacy/proto2_20160225_2fc053c5",
 +        "//internal/testprotos/legacy/proto2_20160519_a4ab9ec5",
 +        "//internal/testprotos/legacy/proto2_20180125_92554152",
@@ -1734,6 +2059,8 @@ diff -urN a/internal/impl/BUILD.bazel b/internal/impl/BUILD.bazel
 +        "//internal/testprotos/legacy/proto3_20180430_b4deda09",
 +        "//internal/testprotos/legacy/proto3_20180814_aa810b61",
 +        "//internal/testprotos/legacy/proto3_20190205_c823c79e",
++        "//internal/testprotos/messageset/messagesetpb",
++        "//internal/testprotos/mixed",
 +        "//internal/testprotos/test",
 +        "//proto",
 +        "//reflect/protodesc",
@@ -1866,6 +2193,32 @@ diff -urN a/internal/protobuild/BUILD.bazel b/internal/protobuild/BUILD.bazel
 +    actual = ":protobuild",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN a/internal/protolazy/BUILD.bazel b/internal/protolazy/BUILD.bazel
+--- a/internal/protolazy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/protolazy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "protolazy",
++    srcs = [
++        "bufferreader.go",
++        "lazy.go",
++        "pointer_unsafe.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/protolazy",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//encoding/protowire",
++        "//runtime/protoiface",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":protolazy",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN a/internal/protolegacy/BUILD.bazel b/internal/protolegacy/BUILD.bazel
 --- a/internal/protolegacy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/protolegacy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -1889,6 +2242,74 @@ diff -urN a/internal/protolegacy/BUILD.bazel b/internal/protolegacy/BUILD.bazel
 +    name = "go_default_library",
 +    actual = ":protolegacy",
 +    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/race_test/file_desc_init/BUILD.bazel b/internal/race_test/file_desc_init/BUILD.bazel
+--- a/internal/race_test/file_desc_init/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/race_test/file_desc_init/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,11 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "file_desc_init_test",
++    srcs = ["race_test.go"],
++    deps = [
++        "//internal/testprotos/race/extender",
++        "//internal/testprotos/race/message",
++        "//proto",
++    ],
++)
+diff -urN a/internal/race_test/lazy/BUILD.bazel b/internal/race_test/lazy/BUILD.bazel
+--- a/internal/race_test/lazy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/race_test/lazy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,12 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "lazy_test",
++    srcs = ["lazy_race_test.go"],
++    deps = [
++        "//internal/test/race",
++        "//internal/testprotos/mixed",
++        "//internal/testprotos/testeditions/testeditions_opaque",
++        "//proto",
++    ],
++)
+diff -urN a/internal/race_test/messageset_extension_init/BUILD.bazel b/internal/race_test/messageset_extension_init/BUILD.bazel
+--- a/internal/race_test/messageset_extension_init/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/race_test/messageset_extension_init/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,7 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "messageset_extension_init_test",
++    srcs = ["race_test.go"],
++    deps = ["//internal/testprotos/messageset/msetextpb"],
++)
+diff -urN a/internal/reflection_test/BUILD.bazel b/internal/reflection_test/BUILD.bazel
+--- a/internal/reflection_test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/reflection_test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,22 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_test")
++
++go_test(
++    name = "reflection_test_test",
++    srcs = [
++        "reflection_hybrid_test.go",
++        "reflection_large_opaque_test.go",
++        "reflection_opaque_test.go",
++        "reflection_open_test.go",
++        "reflection_repeated_test.go",
++        "reflection_test.go",
++    ],
++    deps = [
++        "//internal/testprotos/testeditions",
++        "//internal/testprotos/testeditions/testeditions_hybrid",
++        "//internal/testprotos/testeditions/testeditions_opaque",
++        "//proto",
++        "//reflect/protoreflect",
++        "//runtime/protoiface",
++        "//testing/prototest",
++    ],
 +)
 diff -urN a/internal/set/BUILD.bazel b/internal/set/BUILD.bazel
 --- a/internal/set/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -1945,6 +2366,27 @@ diff -urN a/internal/strs/BUILD.bazel b/internal/strs/BUILD.bazel
 +    name = "strs_test",
 +    srcs = ["strings_test.go"],
 +    embed = [":strs"],
++)
+diff -urN a/internal/test/race/BUILD.bazel b/internal/test/race/BUILD.bazel
+--- a/internal/test/race/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/test/race/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,17 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "race",
++    srcs = [
++        "race_no.go",
++        "race_yes.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/test/race",
++    visibility = ["//:__subpackages__"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":race",
++    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/annotation/BUILD.bazel b/internal/testprotos/annotation/BUILD.bazel
 --- a/internal/testprotos/annotation/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -2173,16 +2615,38 @@ diff -urN a/internal/testprotos/conformance/BUILD.bazel b/internal/testprotos/co
 diff -urN a/internal/testprotos/conformance/editions/BUILD.bazel b/internal/testprotos/conformance/editions/BUILD.bazel
 --- a/internal/testprotos/conformance/editions/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/conformance/editions/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,27 @@
+@@ -0,0 +1,18 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
 +    name = "editions",
++    srcs = ["test_messages_edition2023.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/conformance/editions",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":editions",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/conformance/editionsmigration/BUILD.bazel b/internal/testprotos/conformance/editionsmigration/BUILD.bazel
+--- a/internal/testprotos/conformance/editionsmigration/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/conformance/editionsmigration/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,27 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "editionsmigration",
 +    srcs = [
 +        "test_messages_proto2_editions.pb.go",
 +        "test_messages_proto3_editions.pb.go",
 +    ],
-+    importpath = "google.golang.org/protobuf/internal/testprotos/conformance/editions",
++    importpath = "google.golang.org/protobuf/internal/testprotos/conformance/editionsmigration",
 +    visibility = ["//:__subpackages__"],
 +    deps = [
 +        "//reflect/protoreflect",
@@ -2198,7 +2662,7 @@ diff -urN a/internal/testprotos/conformance/editions/BUILD.bazel b/internal/test
 +
 +alias(
 +    name = "go_default_library",
-+    actual = ":editions",
++    actual = ":editionsmigration",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/editionsfuzztest/BUILD.bazel b/internal/testprotos/editionsfuzztest/BUILD.bazel
@@ -2249,6 +2713,75 @@ diff -urN a/internal/testprotos/enums/BUILD.bazel b/internal/testprotos/enums/BU
 +alias(
 +    name = "go_default_library",
 +    actual = ":enums",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/enums/enums_hybrid/BUILD.bazel b/internal/testprotos/enums/enums_hybrid/BUILD.bazel
+--- a/internal/testprotos/enums/enums_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/enums/enums_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "enums_hybrid",
++    srcs = ["enums.hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/enums/enums_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":enums_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/enums/enums_opaque/BUILD.bazel b/internal/testprotos/enums/enums_opaque/BUILD.bazel
+--- a/internal/testprotos/enums/enums_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/enums/enums_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "enums_opaque",
++    srcs = ["enums.opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/enums/enums_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":enums_opaque",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/examples/ext/BUILD.bazel b/internal/testprotos/examples/ext/BUILD.bazel
+--- a/internal/testprotos/examples/ext/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/examples/ext/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "ext",
++    srcs = ["extexample.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/examples/ext",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":ext",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/fieldtrack/BUILD.bazel b/internal/testprotos/fieldtrack/BUILD.bazel
@@ -2329,33 +2862,79 @@ diff -urN a/internal/testprotos/irregular/BUILD.bazel b/internal/testprotos/irre
 +    actual = ":irregular",
 +    visibility = ["//:__subpackages__"],
 +)
-diff -urN a/internal/testprotos/legacy/bug1052/BUILD.bazel b/internal/testprotos/legacy/bug1052/BUILD.bazel
---- a/internal/testprotos/legacy/bug1052/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/internal/testprotos/legacy/bug1052/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+diff -urN a/internal/testprotos/lazy/BUILD.bazel b/internal/testprotos/lazy/BUILD.bazel
+--- a/internal/testprotos/lazy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/lazy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,24 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
-+    name = "bug1052",
-+    srcs = ["bug1052.pb.go"],
-+    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/bug1052",
++    name = "lazy",
++    srcs = [
++        "lazy_extension_normalized_wire_test.pb.go",
++        "lazy_extension_test.pb.go",
++        "lazy_normalized_wire_test.pb.go",
++        "lazy_tree.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/lazy",
 +    visibility = ["//:__subpackages__"],
 +    deps = [
-+        "//internal/protolegacy",
-+        "//types/descriptorpb",
++        "//internal/testprotos/messageset/messagesetpb",
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
 +    ],
 +)
 +
 +alias(
 +    name = "go_default_library",
-+    actual = ":bug1052",
++    actual = ":lazy",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN a/internal/testprotos/lazy/lazy_hybrid/BUILD.bazel b/internal/testprotos/lazy/lazy_hybrid/BUILD.bazel
+--- a/internal/testprotos/lazy/lazy_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/lazy/lazy_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
-+go_test(
-+    name = "bug1052_test",
-+    srcs = ["bug1052_test.go"],
-+    deps = [":bug1052"],
++go_library(
++    name = "lazy_hybrid",
++    srcs = ["lazy_tree.hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/lazy/lazy_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":lazy_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/lazy/lazy_opaque/BUILD.bazel b/internal/testprotos/lazy/lazy_opaque/BUILD.bazel
+--- a/internal/testprotos/lazy/lazy_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/lazy/lazy_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "lazy_opaque",
++    srcs = ["lazy_tree.opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/lazy/lazy_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":lazy_opaque",
++    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/legacy/BUILD.bazel b/internal/testprotos/legacy/BUILD.bazel
 --- a/internal/testprotos/legacy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -2390,6 +2969,34 @@ diff -urN a/internal/testprotos/legacy/BUILD.bazel b/internal/testprotos/legacy/
 +    name = "go_default_library",
 +    actual = ":legacy",
 +    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/legacy/bug1052/BUILD.bazel b/internal/testprotos/legacy/bug1052/BUILD.bazel
+--- a/internal/testprotos/legacy/bug1052/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/legacy/bug1052/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,24 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
++
++go_library(
++    name = "bug1052",
++    srcs = ["bug1052.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/legacy/bug1052",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/protolegacy",
++        "//types/descriptorpb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":bug1052",
++    visibility = ["//:__subpackages__"],
++)
++
++go_test(
++    name = "bug1052_test",
++    srcs = ["bug1052_test.go"],
++    deps = [":bug1052"],
 +)
 diff -urN a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel b/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel
 --- a/internal/testprotos/legacy/proto2_20160225_2fc053c5/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -2641,6 +3248,52 @@ diff -urN a/internal/testprotos/messageset/messagesetpb/BUILD.bazel b/internal/t
 +    actual = ":messagesetpb",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN a/internal/testprotos/messageset/messagesetpb/messagesetpb_hybrid/BUILD.bazel b/internal/testprotos/messageset/messagesetpb/messagesetpb_hybrid/BUILD.bazel
+--- a/internal/testprotos/messageset/messagesetpb/messagesetpb_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/messageset/messagesetpb/messagesetpb_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "messagesetpb_hybrid",
++    srcs = ["message_set.hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/messageset/messagesetpb/messagesetpb_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":messagesetpb_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/messageset/messagesetpb/messagesetpb_opaque/BUILD.bazel b/internal/testprotos/messageset/messagesetpb/messagesetpb_opaque/BUILD.bazel
+--- a/internal/testprotos/messageset/messagesetpb/messagesetpb_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/messageset/messagesetpb/messagesetpb_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "messagesetpb_opaque",
++    srcs = ["message_set.opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/messageset/messagesetpb/messagesetpb_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":messagesetpb_opaque",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN a/internal/testprotos/messageset/msetextpb/BUILD.bazel b/internal/testprotos/messageset/msetextpb/BUILD.bazel
 --- a/internal/testprotos/messageset/msetextpb/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/messageset/msetextpb/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -2662,6 +3315,77 @@ diff -urN a/internal/testprotos/messageset/msetextpb/BUILD.bazel b/internal/test
 +alias(
 +    name = "go_default_library",
 +    actual = ":msetextpb",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/messageset/msetextpb/msetextpb_hybrid/BUILD.bazel b/internal/testprotos/messageset/msetextpb/msetextpb_hybrid/BUILD.bazel
+--- a/internal/testprotos/messageset/msetextpb/msetextpb_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/messageset/msetextpb/msetextpb_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "msetextpb_hybrid",
++    srcs = ["msetextpb.hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/messageset/msetextpb/msetextpb_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/messageset/messagesetpb/messagesetpb_hybrid",
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":msetextpb_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/messageset/msetextpb/msetextpb_opaque/BUILD.bazel b/internal/testprotos/messageset/msetextpb/msetextpb_opaque/BUILD.bazel
+--- a/internal/testprotos/messageset/msetextpb/msetextpb_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/messageset/msetextpb/msetextpb_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,20 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "msetextpb_opaque",
++    srcs = ["msetextpb.opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/messageset/msetextpb/msetextpb_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/messageset/messagesetpb/messagesetpb_opaque",
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":msetextpb_opaque",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/mixed/BUILD.bazel b/internal/testprotos/mixed/BUILD.bazel
+--- a/internal/testprotos/mixed/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/mixed/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "mixed",
++    srcs = ["mixed.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/mixed",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":mixed",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/news/BUILD.bazel b/internal/testprotos/news/BUILD.bazel
@@ -2746,21 +3470,6 @@ diff -urN a/internal/testprotos/order/BUILD.bazel b/internal/testprotos/order/BU
 +    name = "go_default_library",
 +    actual = ":order",
 +    visibility = ["//:__subpackages__"],
-+)
-diff -urN a/internal/testprotos/race/BUILD.bazel b/internal/testprotos/race/BUILD.bazel
---- a/internal/testprotos/race/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/internal/testprotos/race/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,11 @@
-+load("@io_bazel_rules_go//go:def.bzl", "go_test")
-+
-+go_test(
-+    name = "race_test",
-+    srcs = ["race_test.go"],
-+    deps = [
-+        "//internal/testprotos/race/extender",
-+        "//internal/testprotos/race/message",
-+        "//proto",
-+    ],
 +)
 diff -urN a/internal/testprotos/race/extender/BUILD.bazel b/internal/testprotos/race/extender/BUILD.bazel
 --- a/internal/testprotos/race/extender/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
@@ -2851,10 +3560,56 @@ diff -urN a/internal/testprotos/required/BUILD.bazel b/internal/testprotos/requi
 +    actual = ":required",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN a/internal/testprotos/required/required_hybrid/BUILD.bazel b/internal/testprotos/required/required_hybrid/BUILD.bazel
+--- a/internal/testprotos/required/required_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/required/required_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "required_hybrid",
++    srcs = ["required.hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/required/required_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":required_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/required/required_opaque/BUILD.bazel b/internal/testprotos/required/required_opaque/BUILD.bazel
+--- a/internal/testprotos/required/required_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/required/required_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,19 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "required_opaque",
++    srcs = ["required.opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/required/required_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":required_opaque",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN a/internal/testprotos/test/BUILD.bazel b/internal/testprotos/test/BUILD.bazel
 --- a/internal/testprotos/test/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/testprotos/test/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,25 @@
+@@ -0,0 +1,26 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -2869,6 +3624,7 @@ diff -urN a/internal/testprotos/test/BUILD.bazel b/internal/testprotos/test/BUIL
 +    visibility = ["//:__subpackages__"],
 +    deps = [
 +        "//internal/testprotos/enums",
++        "//internal/testprotos/required",
 +        "//proto",
 +        "//reflect/protoreflect",
 +        "//runtime/protoimpl",
@@ -2951,19 +3707,19 @@ diff -urN a/internal/testprotos/test3/BUILD.bazel b/internal/testprotos/test3/BU
 +    actual = ":test3",
 +    visibility = ["//:__subpackages__"],
 +)
-diff -urN a/internal/testprotos/testeditions/BUILD.bazel b/internal/testprotos/testeditions/BUILD.bazel
---- a/internal/testprotos/testeditions/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
-+++ b/internal/testprotos/testeditions/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+diff -urN a/internal/testprotos/test3/test3_hybrid/BUILD.bazel b/internal/testprotos/test3/test3_hybrid/BUILD.bazel
+--- a/internal/testprotos/test3/test3_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/test3/test3_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
 @@ -0,0 +1,21 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
-+    name = "testeditions",
++    name = "test3_hybrid",
 +    srcs = [
-+        "test.pb.go",
-+        "test_extension.pb.go",
++        "test.hybrid.pb.go",
++        "test_import.hybrid.pb.go",
 +    ],
-+    importpath = "google.golang.org/protobuf/internal/testprotos/testeditions",
++    importpath = "google.golang.org/protobuf/internal/testprotos/test3/test3_hybrid",
 +    visibility = ["//:__subpackages__"],
 +    deps = [
 +        "//reflect/protoreflect",
@@ -2973,7 +3729,118 @@ diff -urN a/internal/testprotos/testeditions/BUILD.bazel b/internal/testprotos/t
 +
 +alias(
 +    name = "go_default_library",
++    actual = ":test3_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/test3/test3_opaque/BUILD.bazel b/internal/testprotos/test3/test3_opaque/BUILD.bazel
+--- a/internal/testprotos/test3/test3_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/test3/test3_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,21 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "test3_opaque",
++    srcs = [
++        "test.opaque.pb.go",
++        "test_import.opaque.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/test3/test3_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":test3_opaque",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/testeditions/BUILD.bazel b/internal/testprotos/testeditions/BUILD.bazel
+--- a/internal/testprotos/testeditions/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/testeditions/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,24 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "testeditions",
++    srcs = [
++        "test.pb.go",
++        "test_extension.pb.go",
++        "test_extension2.pb.go",
++        "test_import.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/testeditions",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/enums",
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++    ],
++)
++
++alias(
++    name = "go_default_library",
 +    actual = ":testeditions",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/testeditions/testeditions_hybrid/BUILD.bazel b/internal/testprotos/testeditions/testeditions_hybrid/BUILD.bazel
+--- a/internal/testprotos/testeditions/testeditions_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/testeditions/testeditions_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "testeditions_hybrid",
++    srcs = [
++        "test.hybrid.pb.go",
++        "test_extension.hybrid.pb.go",
++        "test_extension2.hybrid.pb.go",
++        "test_import.hybrid.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/testeditions/testeditions_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/enums/enums_hybrid",
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":testeditions_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/testeditions/testeditions_opaque/BUILD.bazel b/internal/testprotos/testeditions/testeditions_opaque/BUILD.bazel
+--- a/internal/testprotos/testeditions/testeditions_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/testeditions/testeditions_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,25 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "testeditions_opaque",
++    srcs = [
++        "test.opaque.pb.go",
++        "test_extension.opaque.pb.go",
++        "test_extension2.opaque.pb.go",
++        "test_import.opaque.pb.go",
++    ],
++    importpath = "google.golang.org/protobuf/internal/testprotos/testeditions/testeditions_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//internal/testprotos/enums/enums_opaque",
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":testeditions_opaque",
 +    visibility = ["//:__subpackages__"],
 +)
 diff -urN a/internal/testprotos/textpb2/BUILD.bazel b/internal/testprotos/textpb2/BUILD.bazel
@@ -3056,6 +3923,66 @@ diff -urN a/internal/testprotos/textpbeditions/BUILD.bazel b/internal/testprotos
 +    actual = ":textpbeditions",
 +    visibility = ["//:__subpackages__"],
 +)
+diff -urN a/internal/testprotos/textpbeditions/textpbeditions_hybrid/BUILD.bazel b/internal/testprotos/textpbeditions/textpbeditions_hybrid/BUILD.bazel
+--- a/internal/testprotos/textpbeditions/textpbeditions_hybrid/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/textpbeditions/textpbeditions_hybrid/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "textpbeditions_hybrid",
++    srcs = ["test2.hybrid.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/textpbeditions/textpbeditions_hybrid",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++        "//types/known/anypb",
++        "//types/known/durationpb",
++        "//types/known/emptypb",
++        "//types/known/fieldmaskpb",
++        "//types/known/structpb",
++        "//types/known/timestamppb",
++        "//types/known/wrapperspb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":textpbeditions_hybrid",
++    visibility = ["//:__subpackages__"],
++)
+diff -urN a/internal/testprotos/textpbeditions/textpbeditions_opaque/BUILD.bazel b/internal/testprotos/textpbeditions/textpbeditions_opaque/BUILD.bazel
+--- a/internal/testprotos/textpbeditions/textpbeditions_opaque/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/internal/testprotos/textpbeditions/textpbeditions_opaque/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,26 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "textpbeditions_opaque",
++    srcs = ["test2.opaque.pb.go"],
++    importpath = "google.golang.org/protobuf/internal/testprotos/textpbeditions/textpbeditions_opaque",
++    visibility = ["//:__subpackages__"],
++    deps = [
++        "//reflect/protoreflect",
++        "//runtime/protoimpl",
++        "//types/gofeaturespb",
++        "//types/known/anypb",
++        "//types/known/durationpb",
++        "//types/known/emptypb",
++        "//types/known/fieldmaskpb",
++        "//types/known/structpb",
++        "//types/known/timestamppb",
++        "//types/known/wrapperspb",
++    ],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":textpbeditions_opaque",
++    visibility = ["//:__subpackages__"],
++)
 diff -urN a/internal/version/BUILD.bazel b/internal/version/BUILD.bazel
 --- a/internal/version/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/internal/version/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
@@ -3095,7 +4022,7 @@ diff -urN a/internal/weakdeps/BUILD.bazel b/internal/weakdeps/BUILD.bazel
 diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 --- a/proto/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/proto/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,98 @@
+@@ -0,0 +1,119 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3116,6 +4043,7 @@ diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 +        "reset.go",
 +        "size.go",
 +        "size_gen.go",
++        "wrapperopaque.go",
 +        "wrappers.go",
 +    ],
 +    importpath = "google.golang.org/protobuf/proto",
@@ -3151,37 +4079,56 @@ diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 +        "equal_test.go",
 +        "extension_test.go",
 +        "fuzz_test.go",
++        "lazy_bench_test.go",
++        "lazy_roundtrip_test.go",
 +        "merge_test.go",
 +        "messageset_test.go",
 +        "methods_test.go",
 +        "nil_test.go",
 +        "noenforceutf8_test.go",
++        "oneof_get_test.go",
++        "oneof_set_test.go",
++        "oneof_which_test.go",
++        "repeated_test.go",
 +        "reset_test.go",
++        "size_test.go",
++        "testmessages_opaque_test.go",
 +        "testmessages_test.go",
 +        "validate_test.go",
 +        "weak_test.go",
++        "wrapperopaque_test.go",
 +    ],
 +    deps = [
 +        ":proto",
 +        "//encoding/prototext",
 +        "//encoding/protowire",
-+        "//internal/errors",
 +        "//internal/filedesc",
 +        "//internal/flags",
 +        "//internal/impl",
 +        "//internal/pragma",
 +        "//internal/protobuild",
++        "//internal/test/race",
 +        "//internal/testprotos/editionsfuzztest",
++        "//internal/testprotos/examples/ext",
++        "//internal/testprotos/lazy",
++        "//internal/testprotos/lazy/lazy_opaque",
 +        "//internal/testprotos/legacy",
 +        "//internal/testprotos/legacy/proto2_20160225_2fc053c5",
 +        "//internal/testprotos/messageset/messagesetpb",
++        "//internal/testprotos/messageset/messagesetpb/messagesetpb_opaque",
 +        "//internal/testprotos/messageset/msetextpb",
++        "//internal/testprotos/messageset/msetextpb/msetextpb_opaque",
 +        "//internal/testprotos/order",
 +        "//internal/testprotos/required",
++        "//internal/testprotos/required/required_opaque",
 +        "//internal/testprotos/test",
 +        "//internal/testprotos/test/weak1",
 +        "//internal/testprotos/test3",
++        "//internal/testprotos/test3/test3_hybrid",
++        "//internal/testprotos/test3/test3_opaque",
 +        "//internal/testprotos/testeditions",
++        "//internal/testprotos/testeditions/testeditions_hybrid",
++        "//internal/testprotos/testeditions/testeditions_opaque",
 +        "//reflect/protodesc",
 +        "//reflect/protoreflect",
 +        "//reflect/protoregistry",
@@ -3191,6 +4138,7 @@ diff -urN a/proto/BUILD.bazel b/proto/BUILD.bazel
 +        "//testing/protopack",
 +        "//types/descriptorpb",
 +        "//types/dynamicpb",
++        "//types/known/durationpb",
 +        "@com_github_google_go_cmp//cmp:go_default_library",
 +    ],
 +)
@@ -3220,7 +4168,7 @@ diff -urN a/protoadapt/BUILD.bazel b/protoadapt/BUILD.bazel
 diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
 --- a/reflect/protodesc/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/reflect/protodesc/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,61 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -3238,6 +4186,7 @@ diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
 +    deps = [
 +        "//encoding/protowire",
 +        "//internal/editiondefaults",
++        "//internal/editionssupport",
 +        "//internal/encoding/defval",
 +        "//internal/errors",
 +        "//internal/filedesc",
@@ -3261,7 +4210,11 @@ diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
 +
 +go_test(
 +    name = "protodesc_test",
-+    srcs = ["file_test.go"],
++    srcs = [
++        "editions_test.go",
++        "file_test.go",
++        "proto_test.go",
++    ],
 +    embed = [":protodesc"],
 +    deps = [
 +        "//encoding/prototext",
@@ -3270,7 +4223,11 @@ diff -urN a/reflect/protodesc/BUILD.bazel b/reflect/protodesc/BUILD.bazel
 +        "//proto",
 +        "//reflect/protoreflect",
 +        "//reflect/protoregistry",
++        "//testing/protocmp",
 +        "//types/descriptorpb",
++        "//types/dynamicpb",
++        "//types/gofeaturespb",
++        "@com_github_google_go_cmp//cmp:go_default_library",
 +    ],
 +)
 diff -urN a/reflect/protopath/BUILD.bazel b/reflect/protopath/BUILD.bazel
@@ -3460,7 +4417,7 @@ diff -urN a/runtime/protoiface/BUILD.bazel b/runtime/protoiface/BUILD.bazel
 diff -urN a/runtime/protoimpl/BUILD.bazel b/runtime/protoimpl/BUILD.bazel
 --- a/runtime/protoimpl/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/runtime/protoimpl/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,24 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library")
 +
 +go_library(
@@ -3475,6 +4432,7 @@ diff -urN a/runtime/protoimpl/BUILD.bazel b/runtime/protoimpl/BUILD.bazel
 +        "//internal/filedesc",
 +        "//internal/filetype",
 +        "//internal/impl",
++        "//internal/protolazy",
 +        "//internal/version",
 +    ],
 +)
@@ -3482,6 +4440,25 @@ diff -urN a/runtime/protoimpl/BUILD.bazel b/runtime/protoimpl/BUILD.bazel
 +alias(
 +    name = "go_default_library",
 +    actual = ":protoimpl",
++    visibility = ["//visibility:public"],
++)
+diff -urN a/runtime/protolazy/BUILD.bazel b/runtime/protolazy/BUILD.bazel
+--- a/runtime/protolazy/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
++++ b/runtime/protolazy/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
+@@ -0,0 +1,15 @@
++load("@io_bazel_rules_go//go:def.bzl", "go_library")
++
++go_library(
++    name = "protolazy",
++    srcs = ["protolazy.go"],
++    importpath = "google.golang.org/protobuf/runtime/protolazy",
++    visibility = ["//visibility:public"],
++    deps = ["//internal/impl"],
++)
++
++alias(
++    name = "go_default_library",
++    actual = ":protolazy",
 +    visibility = ["//visibility:public"],
 +)
 diff -urN a/testing/protocmp/BUILD.bazel b/testing/protocmp/BUILD.bazel

--- a/third_party/org_golang_x_sys-gazelle.patch
+++ b/third_party/org_golang_x_sys-gazelle.patch
@@ -1,28 +1,32 @@
 diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
 --- a/cpu/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/cpu/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,68 @@
+@@ -0,0 +1,73 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
 +    name = "cpu",
 +    srcs = [
 +        "asm_aix_ppc64.s",
++        "asm_darwin_x86_gc.s",
 +        "byteorder.go",
 +        "cpu.go",
 +        "cpu_aix.go",
 +        "cpu_arm.go",
 +        "cpu_arm64.go",
 +        "cpu_arm64.s",
++        "cpu_darwin_x86.go",
 +        "cpu_gc_arm64.go",
 +        "cpu_gc_s390x.go",
 +        "cpu_gc_x86.go",
++        "cpu_gc_x86.s",
 +        "cpu_linux.go",
 +        "cpu_linux_arm.go",
 +        "cpu_linux_arm64.go",
 +        "cpu_linux_mips64x.go",
 +        "cpu_linux_noinit.go",
 +        "cpu_linux_ppc64x.go",
++        "cpu_linux_riscv64.go",
 +        "cpu_linux_s390x.go",
 +        "cpu_mips64x.go",
 +        "cpu_mipsx.go",
@@ -31,13 +35,13 @@ diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
 +        "cpu_openbsd_arm64.s",
 +        "cpu_other_arm.go",
 +        "cpu_other_arm64.go",
++        "cpu_other_x86.go",
 +        "cpu_ppc64x.go",
 +        "cpu_riscv64.go",
 +        "cpu_s390x.go",
 +        "cpu_s390x.s",
 +        "cpu_wasm.go",
 +        "cpu_x86.go",
-+        "cpu_x86.s",
 +        "cpu_zos.go",
 +        "cpu_zos_s390x.go",
 +        "endian_big.go",
@@ -48,6 +52,7 @@ diff -urN a/cpu/BUILD.bazel b/cpu/BUILD.bazel
 +        "runtime_auxv.go",
 +        "runtime_auxv_go121.go",
 +        "syscall_aix_ppc64_gc.go",
++        "syscall_darwin_x86_gc.go",
 +    ],
 +    importpath = "golang.org/x/sys/cpu",
 +    visibility = ["//visibility:public"],
@@ -150,7 +155,7 @@ diff -urN a/plan9/BUILD.bazel b/plan9/BUILD.bazel
 diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 --- a/unix/BUILD.bazel	1970-01-01 00:00:00.000000000 +0000
 +++ b/unix/BUILD.bazel	2000-01-01 00:00:00.000000000 -0000
-@@ -0,0 +1,303 @@
+@@ -0,0 +1,308 @@
 +load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 +
 +go_library(
@@ -173,6 +178,8 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +        "asm_linux_riscv64.s",
 +        "asm_linux_s390x.s",
 +        "asm_solaris_amd64.s",
++        "auxv.go",
++        "auxv_unsupported.go",
 +        "bluetooth_linux.go",
 +        "bpxsvc_zos.s",
 +        "cap_freebsd.go",
@@ -263,6 +270,8 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +        "sysvshm_unix_other.go",
 +        "timestruct.go",
 +        "unveil_openbsd.go",
++        "vgetrandom_linux.go",
++        "vgetrandom_unsupported.go",
 +        "xattr_bsd.go",
 +        "zerrors_aix_ppc64.go",
 +        "zerrors_darwin_amd64.go",
@@ -413,6 +422,7 @@ diff -urN a/unix/BUILD.bazel b/unix/BUILD.bazel
 +go_test(
 +    name = "unix_test",
 +    srcs = [
++        "auxv_linux_test.go",
 +        "creds_test.go",
 +        "darwin_amd64_test.go",
 +        "darwin_arm64_test.go",


### PR DESCRIPTION
Bump the versions of dependencies in repositories.bzl to match what's in
go.mod.

Specifically bumps:

  - golang.org/x/sys
  - google.golang.org/protobuf
  - google.golang.org/grpc/cmd/protoc-gen-go-grpc
  - google.golang.org/genproto
  - github.com/golang/mock

Additionally add features to the `releaser` tool for updating to a specific version, rather than latest, so we can avoid further modifications to `go.mod`.

Fixes #4262