### PR TITLE
go_cross: allow transition on compilation_mode

### DIFF
--- a/docs/go/core/rules.md
+++ b/docs/go/core/rules.md
@@ -181,7 +181,7 @@ This builds an executable from a set of source files,
 ## go_cross_binary
 
 <pre>
-go_cross_binary(<a href="#go_cross_binary-name">name</a>, <a href="#go_cross_binary-platform">platform</a>, <a href="#go_cross_binary-sdk_version">sdk_version</a>, <a href="#go_cross_binary-target">target</a>)
+go_cross_binary(<a href="#go_cross_binary-name">name</a>, <a href="#go_cross_binary-compilation_mode">compilation_mode</a>, <a href="#go_cross_binary-platform">platform</a>, <a href="#go_cross_binary-sdk_version">sdk_version</a>, <a href="#go_cross_binary-target">target</a>)
 </pre>
 
 This wraps an executable built by `go_binary` to cross compile it
@@ -199,6 +199,7 @@ This wraps an executable built by `go_binary` to cross compile it
 | Name  | Description | Type | Mandatory | Default |
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="go_cross_binary-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
+| <a id="go_cross_binary-compilation_mode"></a>compilation_mode |  The compilation_mode to use for compiling the <code>target</code>.             Must be one of <code>dbg</code>, <code>fastbuild</code>, or <code>opt</code>. If unspecified, use the             same compilation mode as the original <code>go_binary</code> rule.   | String | optional | "" |
 | <a id="go_cross_binary-platform"></a>platform |  The platform to cross compile the <code>target</code> for.             If unspecified, the <code>target</code> will be compiled with the             same platform as it would've with the original <code>go_binary</code> rule.   | <a href="https://bazel.build/concepts/labels">Label</a> | optional | None |
 | <a id="go_cross_binary-sdk_version"></a>sdk_version |  The golang SDK version to use for compiling the <code>target</code>.             Supports specifying major, minor, and/or patch versions, eg. <code>"1"</code>,             <code>"1.17"</code>, or <code>"1.17.1"</code>. The first Go SDK provider installed in the             repo's workspace (via <code>go_download_sdk</code>, <code>go_wrap_sdk</code>, etc) that             matches the specified version will be used for compiling the given             <code>target</code>. If unspecified, the <code>target</code> will be compiled with the same             SDK as it would've with the original <code>go_binary</code> rule.             Transitions <code>target</code> by changing the <code>--@io_bazel_rules_go//go/toolchain:sdk_version</code>             build flag to the value provided for <code>sdk_version</code> here.   | String | optional | "" |
 | <a id="go_cross_binary-target"></a>target |  Go binary target to transition to the given platform and/or sdk_version.   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |

--- a/go/private/rules/cross.bzl
+++ b/go/private/rules/cross.bzl
@@ -116,6 +116,19 @@ _go_cross_kwargs = {
             build flag to the value provided for `sdk_version` here.
             """,
         ),
+        "compilation_mode": attr.string(
+            doc = """The compilation_mode to use for compiling the `target`.
+            Must be one of `dbg`, `fastbuild`, or `opt`. If unspecified, use the
+            same compilation mode as the original `go_binary` rule.
+            """,
+            values = [
+                "",
+                "dbg",
+                "fastbuild",
+                "opt",
+            ],
+            default = "",
+        ),
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -418,6 +418,7 @@ def _set_ternary(settings, attr, name):
 _SDK_VERSION_BUILD_SETTING = "//go/toolchain:sdk_version"
 TRANSITIONED_GO_CROSS_SETTING_KEYS = [
     _SDK_VERSION_BUILD_SETTING,
+    "//command_line_option:compilation_mode",
     "//command_line_option:platforms",
 ]
 
@@ -425,6 +426,9 @@ def _go_cross_transition_impl(settings, attr):
     settings = dict(settings)
     if attr.sdk_version != None:
         settings[_SDK_VERSION_BUILD_SETTING] = attr.sdk_version
+
+    if attr.compilation_mode != "":
+        settings["//command_line_option:compilation_mode"] = attr.compilation_mode
 
     if attr.platform != None:
         settings["//command_line_option:platforms"] = str(attr.platform)


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Let user change the compilation mode with go_cross_binary.
This is useful to force a opt mode for a deployment or packaging
purposes.

**Which issues(s) does this PR fix?**

**Other notes for review**
