### PR TITLE
docs: added note about x/tools when using vet with nogo

### DIFF
--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -355,6 +355,8 @@ Setting ``vet = True`` is equivalent to adding the ``atomic``, ``bools``,
 ``@org_golang_x_tools//go/analysis/passes`` to the ``deps`` list of your
 ``nogo`` rule.
 
+**NOTE**: When using vet you must ensure that the package ``golang.org/x/tools`` is in the go.mod file.
+
 
 See the full list of available nogo checks:
 


### PR DESCRIPTION


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Documentation

**What does this PR do? Why is it needed?**
Makes it visible that there is a dependency on `golang.org/x/tools`.
If `golang.org/x/tools` is not in the go.mod file, then you get import errors on the standard library when using nogo.

**Other notes for review**
