### PR TITLE
Export new location of support files needed for using Go's WASM output.

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -117,7 +117,11 @@ filegroup(
 exports_files(
     glob([
         "lib/time/zoneinfo.zip",
-        "misc/wasm/**",
+        # wasm support files including wasm_exec.js
+        # for GOOS=js GOARCH=wasm
+        # located in misc/wasm/ (Go 1.23 and earlier)
+        # or lib/wasm/ (Go 1.24 and later)
+        "*/wasm/**",
     ]),
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**


Bug fix

**What does this PR do? Why is it needed?**

In order to run code with GOOS=js GOARCH=wasm in the browser, you need to copy a `.js` file from the toolchain.
This file location was changed in Go 1.24, which is now also exported in this PR.

**Which issues(s) does this PR fix?**

n/a

**Other notes for review**

See also this info from the Go wiki:

> For Go 1.23 and earlier, the wasm support files needed in this article are located in misc/wasm, and the path should be replaced when performing operations with files such as lib/wasm/wasm_exec.js.

[source](https://go.dev/wiki/WebAssembly)