### PR TITLE
Checking test suite duration

### DIFF
--- a/go/tools/bzltestutil/xml.go
+++ b/go/tools/bzltestutil/xml.go
@@ -188,7 +188,10 @@ func toXML(pkgName string, testcases map[string]*testCase) *xmlTestSuites {
 		}
 		c := testcases[name]
 		if name == suiteName {
-			duration := *c.duration
+			var duration float64
+			if c.duration != nil {
+				duration = *c.duration
+			}
 			if c.start != nil && c.end != nil {
 				// the duration of a test suite may be greater than c.duration
 				// when any test case uses t.Parallel().


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
A test case/suite's duration can be nil in the test JSON. We should check it before dereference it.

**Which issues(s) does this PR fix?**

Fixes #4318

**Other notes for review**
