### PR TITLE
Re-spawned test binary should not break PWD

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -192,7 +192,13 @@ def _go_test_impl(ctx):
         info_file = ctx.info_file,
     )
 
-    env = {}
+    env = {
+        # The test binary uses this to decide
+        # whether it was invoked by Bazel or directly.
+        # If invoked directly, it will not change its working directory
+        # to run_dir configured above.
+        "GO_TEST_RUN_FROM_BAZEL": "1",
+    }
     for k, v in ctx.attr.env.items():
         env[k] = ctx.expand_location(v, ctx.attr.data)
 

--- a/go/tools/builders/generate_test_main.go
+++ b/go/tools/builders/generate_test_main.go
@@ -165,6 +165,15 @@ func testsInShard() []testing.InternalTest {
 }
 
 func main() {
+	// When the test process is originally spawned by Bazel,
+	// it should run in a test directory.
+	// However, if the test process is re-spawned by the test,
+	// it should run wherever that process is set to run.
+	//
+	// Clearing this environment variable will opt the child process
+	// out of the Chdir behavior.
+	_ = os.Unsetenv("GO_TEST_RUN_FROM_BAZEL")
+
 	if bzltestutil.ShouldWrap() {
 		err := bzltestutil.Wrap("{{.Pkgname}}")
 		exitCode := 0

--- a/go/tools/bzltestutil/chdir/init.go
+++ b/go/tools/bzltestutil/chdir/init.go
@@ -75,6 +75,10 @@ var (
 const isWindows = os.PathSeparator == '\\'
 
 func init() {
+	if os.Getenv("GO_TEST_RUN_FROM_BAZEL") == "" {
+		return
+	}
+
 	var err error
 	TestExecDir, err = os.Getwd()
 	if err != nil {

--- a/tests/core/go_test/BUILD.bazel
+++ b/tests/core/go_test/BUILD.bazel
@@ -106,6 +106,12 @@ go_test(
 )
 
 go_test(
+    name = "testmain_pwd_test",
+    size = "small",
+    srcs = ["testmain_pwd_test.go"],
+)
+
+go_test(
     name = "data_test",
     size = "small",
     embed = [":data_test_lib"],

--- a/tests/core/go_test/README.rst
+++ b/tests/core/go_test/README.rst
@@ -120,6 +120,12 @@ wrapper_test
 Checks that a ``go_test`` can be executed by another test in a subdirectory.
 Verifies `#2749`_.
 
+testmain_pwd_test
+-----------------
+
+Checks that a test which spawns a subprocess of the test binary
+is run inside the correct directory.
+
 fuzz_test
 ---------
 

--- a/tests/core/go_test/testmain_pwd_test.go
+++ b/tests/core/go_test/testmain_pwd_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package testmain_pwd_test
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+var testExecutable string // set in TestMain if we're running tests
+
+func TestMain(m *testing.M) {
+	if filepath.Base(os.Args[0]) == "pwd" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("failed to get current working directory: %v", err)
+		}
+
+		fmt.Println(cwd)
+		os.Exit(0)
+	}
+
+	var err error
+	testExecutable, err = os.Executable()
+	if err != nil {
+		log.Fatalf("failed to get executable path: %v", err)
+	}
+
+	os.Exit(m.Run())
+}
+
+// Creates a $tmp/pwd symlink to the test executable and run it.
+func TestSymlinkToBinary(t *testing.T) {
+	workDir := t.TempDir()
+
+	pwdExe := filepath.Join(workDir, "pwd")
+	if err := os.Symlink(testExecutable, pwdExe); err != nil {
+		t.Fatalf("failed to create symlink: %v", err)
+	}
+
+	cmd := exec.Command(pwdExe)
+	cmd.Dir = workDir
+	bs, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to run symlinked executable: %v", err)
+	}
+
+	gotPath := strings.TrimSpace(string(bs))
+	if !sameFile(t, gotPath, workDir) {
+		t.Fatalf("subprocess inside the incorrect directory:\n"+
+			"want: %s\n got: %s", workDir, gotPath)
+	}
+}
+
+func TestChangeOSArgs0(t *testing.T) {
+	workDir := t.TempDir()
+
+	cmd := exec.Command(testExecutable)
+	cmd.Args[0] = "pwd"
+	cmd.Dir = workDir
+	bs, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("failed to run symlinked executable: %v", err)
+	}
+
+	gotPath := strings.TrimSpace(string(bs))
+	if !sameFile(t, gotPath, workDir) {
+		t.Fatalf("subprocess inside the incorrect directory:\n"+
+			"want: %s\n got: %s", workDir, gotPath)
+	}
+}
+
+// Reports whether two paths point to the same file or directory.
+func sameFile(t testing.TB, a, b string) bool {
+	aStat, err := os.Stat(a)
+	if err != nil {
+		t.Fatalf("failed to stat %q: %v", a, err)
+	}
+	bStat, err := os.Stat(b)
+	if err != nil {
+		t.Fatalf("failed to stat %q: %v", b, err)
+	}
+	return os.SameFile(aStat, bStat)
+}

--- a/tests/core/go_test/testmain_pwd_test.go
+++ b/tests/core/go_test/testmain_pwd_test.go
@@ -20,14 +20,22 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
-var testExecutable string // set in TestMain if we're running tests
+var (
+	exeSuffix      string // set in TestMain only on Windows
+	testExecutable string // set in TestMain if we're running tests
+)
 
 func TestMain(m *testing.M) {
-	if filepath.Base(os.Args[0]) == "pwd" {
+	if runtime.GOOS == "windows" {
+		exeSuffix = ".exe"
+	}
+
+	if filepath.Base(os.Args[0]) == "pwd"+exeSuffix {
 		cwd, err := os.Getwd()
 		if err != nil {
 			log.Fatalf("failed to get current working directory: %v", err)
@@ -50,7 +58,7 @@ func TestMain(m *testing.M) {
 func TestSymlinkToBinary(t *testing.T) {
 	workDir := t.TempDir()
 
-	pwdExe := filepath.Join(workDir, "pwd")
+	pwdExe := filepath.Join(workDir, "pwd"+exeSuffix)
 	if err := os.Symlink(testExecutable, pwdExe); err != nil {
 		t.Fatalf("failed to create symlink: %v", err)
 	}
@@ -73,7 +81,7 @@ func TestChangeOSArgs0(t *testing.T) {
 	workDir := t.TempDir()
 
 	cmd := exec.Command(testExecutable)
-	cmd.Args[0] = "pwd"
+	cmd.Args[0] = "pwd" + exeSuffix
 	cmd.Dir = workDir
 	bs, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR adds a test to reproduce the issue described in #4335,
and proposes one possible fix for it:
leveraging an environment variable to help the subprocess determine
whether it was invoked by Bazel or directly.

The test fails without the proposed fix,
but it succeeds fine with `go test`.

**Which issues(s) does this PR fix?**

Fixes #4335

**Other notes for review**

The proposed fix is one possible way of doing this.
I welcome feedback from maintainers on other approaches here.