### PR TITLE
go/tools/gopackagesdriver: Adding Cgo support

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -86,7 +86,10 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     importmap = "main" if source.is_main else source.importmap
     importpath, _ = effective_importpath_pkgpath(source)
 
+    cgo_out_dir = None
     if source.cgo and not go.mode.pure:
+        cgo_out_dir = go.declare_directory(go, path = out_lib.basename + ".cgo")
+
         # TODO(jayconrod): do we need to do full Bourne tokenization here?
         cppopts = [f for fs in source.cppopts for f in fs.split(" ")]
         copts = [f for fs in source.copts for f in fs.split(" ")]
@@ -123,6 +126,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
             gc_goopts = source.gc_goopts,
             cgo = True,
             cgo_inputs = cgo.inputs,
+            cgo_out_dir = cgo_out_dir,
             cppopts = cgo.cppopts,
             copts = cgo.copts,
             cxxopts = cgo.cxxopts,
@@ -170,6 +174,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         importpath_aliases = source.importpath_aliases,
         pathtype = source.pathtype,
         srcs = tuple(source.srcs),
+        cgo_out_dir = cgo_out_dir,
         _cover = source.cover,
         _embedsrcs = tuple(source.embedsrcs),
         _x_defs = tuple(source.x_defs.items()),

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -59,6 +59,7 @@ def emit_compilepkg(
         archives = [],
         cgo = False,
         cgo_inputs = depset(),
+        cgo_out_dir = None,
         cppopts = [],
         copts = [],
         cxxopts = [],
@@ -171,12 +172,12 @@ def emit_compilepkg(
     else:
         env = go.env_for_path_mapping
         execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT
-    cgo_go_srcs_for_nogo = None
+    cgo_go_srcs = None
     if cgo:
-        if nogo:
-            cgo_go_srcs_for_nogo = go.declare_directory(go, path = out_lib.basename + ".cgo")
-            outputs.append(cgo_go_srcs_for_nogo)
-            compile_args.add("-cgo_go_srcs", cgo_go_srcs_for_nogo.path)
+        if cgo_out_dir:
+            cgo_go_srcs = cgo_out_dir
+            outputs.append(cgo_go_srcs)
+            compile_args.add("-cgo_go_srcs", cgo_go_srcs.path)
         inputs_transitive.append(cgo_inputs)
         inputs_transitive.append(go.cc_toolchain_files)
         env["CC"] = go.cgo_tools.c_compiler_path
@@ -213,7 +214,7 @@ def emit_compilepkg(
             go,
             shared_args = shared_args,
             sources = sources,
-            cgo_go_srcs = cgo_go_srcs_for_nogo,
+            cgo_go_srcs = cgo_go_srcs,
             archives = archives,
             out_diagnostics = out_diagnostics,
             out_facts = out_facts,

--- a/go/tools/builders/cgo2.go
+++ b/go/tools/builders/cgo2.go
@@ -159,6 +159,9 @@ func cgo2(goenv *env, goSrcs, cgoSrcs, cSrcs, cxxSrcs, objcSrcs, objcxxSrcs, sSr
 			return "", nil, nil, err
 		}
 	}
+	// Note: The tools/gopackagesdriver will break if the naming convention
+	// changes for genGoSrcs files. Changes here should be reflected
+	// there.
 	genGoSrcs := make([]string, 1+len(cgoSrcs))
 	genGoSrcs[0] = filepath.Join(workDir, "_cgo_gotypes.go")
 	genCSrcs := make([]string, 1+len(cgoSrcs))

--- a/go/tools/gopackagesdriver/BUILD.bazel
+++ b/go/tools/gopackagesdriver/BUILD.bazel
@@ -52,6 +52,6 @@ go_bazel_test(
 filegroup(
     name = "all_files",
     testonly = True,
-    srcs = glob(["**"]),
+    srcs = glob(["**"]) + ["//go/tools/gopackagesdriver/pkgjson:all_files"],
     visibility = ["//visibility:public"],
 )

--- a/go/tools/gopackagesdriver/build_context.go
+++ b/go/tools/gopackagesdriver/build_context.go
@@ -24,11 +24,19 @@ func filterSourceFilesForTags(files []string) []string {
 
 		match, _ := buildContext.MatchFile(dir, filename)
 		// MatchFile filters out anything without a file extension. In the
-		// case of CompiledGoFiles (in particular gco processed files from
-		// the cache), we want them.
-		if match || ext == "" {
+		// case of CompiledGoFiles (in particular cgo processed files from
+		// the cache), we want them. We also want to keep cgo processed files
+		// with known naming conventions.
+		if match || ext == "" || isCgoProcessed(filename) {
 			ret = append(ret, f)
 		}
 	}
 	return ret
+}
+
+// isCgoProcessed returns true if the file is a cgo processed file.
+func isCgoProcessed(fileName string) bool {
+	// go/tools/builders/cgo2.go generates cgo processed code that are
+	// named *.cgo1.go, _cgo_gotypes.go, and _cgo_imports.go.
+	return fileName == "_cgo_gotypes.go" || fileName == "_cgo_imports.go" || strings.HasSuffix(fileName, ".cgo1.go")
 }

--- a/go/tools/gopackagesdriver/pkgjson/BUILD.bazel
+++ b/go/tools/gopackagesdriver/pkgjson/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@io_bazel_rules_go//go/private/rules:transition.bzl", "go_reset_target")
+load("//go:def.bzl", "go_binary", "go_library")
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+    ],
+    visibility = [
+        "//visibility:public",
+    ],
+)
+
+go_binary(
+    name = "pkgjson",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_reset_target(
+    name = "reset_pkgjson",
+    dep = ":pkgjson",
+    visibility = ["//visibility:public"],
+)

--- a/go/tools/gopackagesdriver/pkgjson/main.go
+++ b/go/tools/gopackagesdriver/pkgjson/main.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+)
+
+var (
+	bazelBin              = getenvDefault("GOPACKAGESDRIVER_BAZEL", "bazel")
+	bazelStartupFlags     = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_FLAGS"))
+	bazelCommonFlags      = strings.Fields(os.Getenv("GOPACKAGESDRIVER_BAZEL_COMMON_FLAGS"))
+	workspaceRoot         = os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	buildWorkingDirectory = os.Getenv("BUILD_WORKING_DIRECTORY")
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		log.Fatalf("write package json: %v", err)
+	}
+}
+
+type params struct {
+	id string
+	pkgPath string
+	exportFile string
+	goFiles []string
+	compiledGoFiles []string
+	otherFiles []string
+	imports map[string]string
+	cgoOutDir string
+	// path to write the pkgjson
+	output string
+}
+
+type pkgJson struct {
+	ID string `json:"ID"`
+	PkgPath string `json:"PkgPath"`
+	ExportFile string `json:"ExportFile"`
+	GoFiles []string `json:"GoFiles"`
+	CompiledGoFiles []string `json:"CompiledGoFiles"`
+	OtherFiles []string `json:"OtherFiles"`
+	Imports map[string]string `json:"Imports"`
+}
+
+func parseArgs(args []string) (*params, error) {
+	var params params
+
+	fs := flag.NewFlagSet("pkgjson", flag.ContinueOnError)
+	fs.StringVar(&params.id, "id", "", "id")
+	fs.StringVar(&params.pkgPath, "pkg_path", "", "package path")
+	fs.StringVar(&params.exportFile, "export_file", "", "export file")
+	fs.StringVar(&params.cgoOutDir, "cgo_out_dir", "", "cgo out dir")
+	rawGoFiles := fs.String("go_files", "", "a comma separated list of go files")
+	rawCompiledGoFiles := fs.String("compiled_go_files", "", "a comma separated list of compiled go files")
+	rawOtherFiles := fs.String("other_files", "", "a comma separated list of other files")
+	rawImports := fs.String("imports", "", "comma separate pairs of importpath=label")
+	fs.StringVar(&params.output, "output", "", "path to write the pkgjson")
+
+	err := fs.Parse(args)
+	if err != nil {
+		return nil, err
+	}
+
+	params.goFiles = strings.Split(*rawGoFiles, ",")
+	params.compiledGoFiles = strings.Split(*rawCompiledGoFiles, ",")
+	params.otherFiles = strings.Split(*rawOtherFiles, ",")
+	params.imports = make(map[string]string)
+	if len(*rawImports) > 0 {
+		for _, rawImport := range strings.Split(*rawImports, ",") {
+			parts := strings.Split(rawImport, "=")
+			params.imports[parts[0]] = parts[1]
+		}
+	}
+
+	return &params, nil
+}
+
+func run(args []string) error {
+	params, err := parseArgs(args)
+	if err != nil {
+		return err
+	}
+	data := pkgJson{
+		ID: params.id,
+		PkgPath: params.pkgPath,
+		ExportFile: params.exportFile,
+		GoFiles: params.goFiles,
+		CompiledGoFiles: params.compiledGoFiles,
+		OtherFiles: params.otherFiles,
+		Imports: params.imports,
+	}
+	if err = processCgoFiles(params.cgoOutDir, &data, resolvePath); err != nil {
+		return err
+	}
+	marshaled, err := json.Marshal(data)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(params.output, marshaled, 0644)
+}
+
+// go/tools/gopackagesdriver uses special Bazel file prefixes to resolve paths
+// in package json files to absolute paths. This function strips these prefixes
+// which returns paths relative to the execroot.
+// The prefixes are defined in:
+// github.com/bazel-contrib/rules_go/go/tools/gopackagesdriver/pkgjson/pkg_json.bzl
+func resolvePath(p string) string {
+	if strings.HasPrefix(p, "__BAZEL_OUTPUT_BASE__") {
+		return strings.TrimPrefix(p, "__BAZEL_OUTPUT_BASE__/")
+	}
+	if strings.HasPrefix(p, "__BAZEL_EXECROOT__") {
+		return strings.TrimPrefix(p, "__BAZEL_EXECROOT__/")
+	}
+	if strings.HasPrefix(p, "__BAZEL_WORKSPACE__") {
+		return strings.TrimPrefix(p, "__BAZEL_WORKSPACE__/")
+	}
+	return p
+}
+
+// processCgoFiles ensures that the CompiledGoFiles field of the package json does not contain
+// any cgo source files and contains cgo generated files.
+func processCgoFiles(cgoOutDir string, p *pkgJson, pathResolver func(string) string) error {
+	cf, err := filterCgoSourceFiles(p.CompiledGoFiles, pathResolver)
+	if err != nil {
+		return err
+	}
+	p.CompiledGoFiles = cf.goSourceFiles
+	if cgoOutDir == "" {
+		return nil
+	}
+	cgoSrcs, err := cgoGoSrcs(cgoOutDir, cf.cgoSourceFiles, pathResolver)
+	if err != nil {
+		return err
+	}
+	p.CompiledGoFiles = append(p.CompiledGoFiles, cgoSrcs...)
+	return nil
+}
+
+type cgoFiles struct {
+	cgoSourceFiles []string
+	goSourceFiles []string
+}
+
+func filterCgoSourceFiles(compiledGoFiles []string, resolvePath func(string) string) (cgoFiles, error) {
+	filtered := make([]string, 0, len(compiledGoFiles))
+	var cgoSourceFiles []string
+	fset := token.NewFileSet()
+	for _, file := range compiledGoFiles {
+		// Note: We check resolved file paths to get a path relative to the execroot
+		// but we add the unresolved file path to the package json as the gopackagesdriver
+		// uses the special bazel prefixes to resolve to absolute paths.
+		resolvedPath := resolvePath(file)
+		f, err := parser.ParseFile(fset, resolvedPath, nil, parser.ImportsOnly)
+		if err != nil {
+			return cgoFiles{}, err
+		}
+		var skip bool
+		for _, rawImport := range f.Imports {
+			imp, err := strconv.Unquote(rawImport.Path.Value)
+			if err != nil {
+				continue
+			}
+			if imp == "C" {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			// Skip Cgo preprocessed files.
+			cgoSourceFiles = append(cgoSourceFiles, file)
+		} else {
+			filtered = append(filtered, file)
+		}
+	}
+	return cgoFiles{
+		cgoSourceFiles: cgoSourceFiles,
+		goSourceFiles:  filtered,
+	}, nil
+}
+
+func cgoGoSrcs(cgoGeneratedDir string, cgoSourceFiles []string, resolvePath func(string) string) ([]string, error) {
+	var cgoGeneratedFiles []string
+	// Only include cgo generated files if they were generated by Bazel, using
+	// the _cgo_gotypes.go file name as a marker for cgo files as it's always
+	// present if the package contains cgo generated code.
+	//
+	// Note: We check resolved file paths to get a path relative to the execroot
+	// but we add the unresolved file path to the package json as the gopackagesdriver
+	// uses the special bazel prefixes to resolve to absolute paths.
+	resolvedCgoGeneratedDir := resolvePath(cgoGeneratedDir)
+	cgoGotypesPath := filepath.Join(resolvedCgoGeneratedDir, "_cgo_gotypes.go")
+	if _, err := os.Stat(cgoGotypesPath); err != nil && os.IsNotExist(err) {
+		return nil, nil
+	}
+	cgoGeneratedFiles = append(
+		cgoGeneratedFiles,
+		filepath.Join(cgoGeneratedDir, "_cgo_gotypes.go"),
+		filepath.Join(cgoGeneratedDir, "_cgo_imports.go"),
+	)
+	for _, csf := range cgoSourceFiles {
+		name := strings.TrimSuffix(filepath.Base(csf), ".go")
+		name = name + ".cgo1.go"
+		resolvedPath := filepath.Join(resolvedCgoGeneratedDir, name)
+		unresolvedPath := filepath.Join(cgoGeneratedDir, name)
+		if _, err := os.Stat(resolvedPath); err != nil && os.IsNotExist(err) {
+			// Check if the cgo generated file exists. Due to situations
+			// like OS-specific build tags, we can't determine whether a cgo
+			// processed file is generated ahead of time.
+			continue
+		} else {
+			cgoGeneratedFiles = append(cgoGeneratedFiles, unresolvedPath)
+		}
+	}
+	return cgoGeneratedFiles, nil
+}
+
+// getenvDefault returns the value of the environment variable key.
+// If the variable is not set, it returns defaultValue.
+func getenvDefault(key, defaultValue string) string {
+	if v, ok := os.LookupEnv(key); ok {
+		return v
+	}
+	return defaultValue
+}

--- a/go/tools/gopackagesdriver/pkgjson/pkg_json.bzl
+++ b/go/tools/gopackagesdriver/pkgjson/pkg_json.bzl
@@ -1,0 +1,50 @@
+load(
+    "@bazel_skylib//lib:paths.bzl",
+    "paths",
+)
+
+def write_pkg_json(ctx, pkg_json_tool, archive, output_json):
+    inputs = [src for src in archive.data.srcs if src.path.endswith(".go")]
+    input_paths = [file_path(src) for src in inputs]
+    cgo_out_dir = ""
+    if archive.data.cgo_out_dir:
+        inputs.append(archive.data.cgo_out_dir)
+        cgo_out_dir = file_path(archive.data.cgo_out_dir)
+
+    ctx.actions.run(
+        inputs = inputs,
+        outputs = [output_json],
+        executable = pkg_json_tool,
+        arguments = [
+            "--id",
+            str(archive.data.label),
+            "--pkg_path",
+            archive.data.importpath,
+            "--export_file",
+            file_path(archive.data.export_file),
+            "--go_files",
+            ",".join(input_paths),
+            "--compiled_go_files",
+            ",".join(input_paths),
+            "--cgo_out_dir",
+            cgo_out_dir,
+            "--other_files",
+            ",".join([file_path(src) for src in archive.data.srcs if not src.path.endswith(".go")]),
+            "--imports",
+            ",".join([pkg.data.importpath + "=" + str(pkg.data.label) for pkg in archive.direct]),
+            "--output",
+            output_json.path,
+        ],
+        tools = [pkg_json_tool],
+    )
+
+def file_path(f):
+    prefix = "__BAZEL_WORKSPACE__"
+    if not f.is_source:
+        prefix = "__BAZEL_EXECROOT__"
+    elif is_file_external(f):
+        prefix = "__BAZEL_OUTPUT_BASE__"
+    return paths.join(prefix, f.path)
+
+def is_file_external(f):
+    return f.owner.workspace_root != ""


### PR DESCRIPTION
go/tools/gopackagesdriver: Filter cgo sources and add cgo processed files
    
The gopackagesdriver today fails to load Go programs
with cgo dependencies.
```
go-code/bazel-pkgdrv/external/com_github_mattn_go_sqlite3/backup.go:16:8: could not import C (no metadata for C)
```

These errors come from two sources:
- First, the gopackagesdriver includes cgo sources files in the
  CompiledGoFiles response.
- Second, the gopackagesdriver response and CompiledGoFiles do not
  contain cgo processed Go sources necessary to compile the program.

This change addresses both error points by
- Exposing the location of cgo generated artifacts in the rules_go archive object.
- Filtering out cgo source files from the CompiledGoFiles response, by
checking if the files import "C".
- Adding cgo processed files to the CompiledGoFiles response by exploiting
knowledge of how rules_go compiles cgo files.

I am not sure if there is a better solution to leaking build system
details to the gopackagesdriver as even 'go list' leaks where
the go build cache stores cgo processed files. Though in the case of 'go list'
the conventions for cgo processed files are a bit different, they don't
seem to have a file extension.

For example,
```
$ go list -json=ImportPath,CgoFiles,GoFiles,CompiledGoFiles -compiled -find github.com/mattn/go-sqlite3
 "CompiledGoFiles": [
                "convert.go",
                "doc.go",
                "sqlite3_func_crypt.go",
                "sqlite3_go18.go",
                "sqlite3_opt_preupdate.go",
                "sqlite3_opt_preupdate_omit.go",
                "/Users/rhang/Library/Caches/go-build/8f/8f8bfe0b75fcceeb093e990af3eaa4f05147147b13db050b2f706cb563280415-d",
                "/Users/rhang/Library/Caches/go-build/9c/9c0b42e0a548721eb17f0fe5cfc2b6f1c0f0f7fcfb0f0caf526229723b9d4927-d",
                "/Users/rhang/Library/Caches/go-build/f7/f7e25424abcdc8442dbe22670456cab79a881268995c4ed43715e6d56930bff6-d",
...
```

This PR resolves https://github.com/bazel-contrib/rules_go/issues/4337 additional
details are provided in the issue.