### PR TITLE
Remove rules_proto

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,7 +11,6 @@ module(
 bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.10")
-bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ module(
 bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
 bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_shell", version = "0.3.0")
 

--- a/docs/go/core/workspace.md
+++ b/docs/go/core/workspace.md
@@ -248,7 +248,7 @@ protobuf_deps()
 You'll need a C/C++ toolchain registered for the execution platform (the
 platform where Bazel runs actions) to build protoc.
 
-The `proto_library` rule is provided by the `rules_proto` repository.
+The `proto_library` rule is provided by the `com_google_protobuf` repository.
 `protoc-gen-go`, the Go proto compiler plugin, is provided by the
 `com_github_golang_protobuf` repository. Both are declared by
 `go_rules_dependencies`. You won't need to declare an explicit dependency
@@ -267,7 +267,7 @@ and `go_proto_library` rules to generate and compile Go code from .proto
 files.
 
 ```starlark
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -16,10 +16,7 @@ load(
     "@bazel_skylib//lib:paths.bzl",
     "paths",
 )
-load(
-    "@rules_proto//proto:proto_common.bzl",
-    proto_toolchains = "toolchains",
-)
+load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
 load(
     "//go:def.bzl",
     "GoInfo",
@@ -188,7 +185,7 @@ def proto_path(src, proto):
 def _go_proto_compiler_impl(ctx):
     go = go_context(ctx, include_deprecated_properties = False)
     go_info = new_go_info(go, ctx.attr)
-    proto_toolchain = proto_toolchains.find_toolchain(
+    proto_toolchain = _find_toolchain(
         ctx,
         legacy_attr = "_legacy_proto_toolchain",
         toolchain_type = _PROTO_TOOLCHAIN_TYPE,
@@ -233,7 +230,7 @@ _go_proto_compiler = rule(
         "_go_context_data": attr.label(
             default = "//:go_context_data",
         ),
-    }, **proto_toolchains.if_legacy_toolchain({
+    }, **_if_legacy_toolchain({
         "_legacy_proto_toolchain": attr.label(
             # Setting cfg = "exec" here as the legacy_proto_toolchain target
             # already needs to apply the non_go_tool_transition. Flipping the
@@ -243,7 +240,7 @@ _go_proto_compiler = rule(
             default = "//proto/private:legacy_proto_toolchain",
         ),
     })),
-    toolchains = [GO_TOOLCHAIN] + proto_toolchains.use_toolchain(_PROTO_TOOLCHAIN_TYPE),
+    toolchains = [GO_TOOLCHAIN] + _use_toolchain(_PROTO_TOOLCHAIN_TYPE),
 )
 
 def go_proto_compiler(name, **kwargs):
@@ -259,3 +256,29 @@ def go_proto_compiler(name, **kwargs):
         plugin = reset_plugin_name,
         **kwargs
     )
+
+
+def _incompatible_toolchains_enabled():
+    return getattr(proto_common, "INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION", False)
+
+def _find_toolchain(ctx, legacy_attr, toolchain_type):
+    if _incompatible_toolchains_enabled():
+        toolchain = ctx.toolchains[toolchain_type]
+        if not toolchain:
+            fail("No toolchains registered for '%s'." % toolchain_type)
+        return toolchain.proto
+    else:
+        return getattr(ctx.attr, legacy_attr)[ProtoLangToolchainInfo]
+
+def _use_toolchain(toolchain_type):
+    if _incompatible_toolchains_enabled():
+        return [config_common.toolchain_type(toolchain_type, mandatory = False)]
+    else:
+        return []
+
+def _if_legacy_toolchain(legacy_attr_dict):
+    if _incompatible_toolchains_enabled():
+        return {}
+    else:
+        return legacy_attr_dict
+

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -284,5 +284,3 @@ def go_proto_compiler(name, **kwargs):
         plugin = reset_plugin_name,
         **kwargs
     )
-
-

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -49,6 +49,30 @@ load(
 #  default.
 _PROTO_TOOLCHAIN_TYPE = "@rules_proto//proto:toolchain_type"
 
+def _incompatible_toolchains_enabled():
+    return getattr(proto_common, "INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION", False)
+
+def _find_toolchain(ctx, legacy_attr, toolchain_type):
+    if _incompatible_toolchains_enabled():
+        toolchain = ctx.toolchains[toolchain_type]
+        if not toolchain:
+            fail("No toolchains registered for '%s'." % toolchain_type)
+        return toolchain.proto
+    else:
+        return getattr(ctx.attr, legacy_attr)[ProtoLangToolchainInfo]
+
+def _use_toolchain(toolchain_type):
+    if _incompatible_toolchains_enabled():
+        return [config_common.toolchain_type(toolchain_type, mandatory = False)]
+    else:
+        return []
+
+def _if_legacy_toolchain(legacy_attr_dict):
+    if _incompatible_toolchains_enabled():
+        return {}
+    else:
+        return legacy_attr_dict
+
 GoProtoCompiler = provider(
     doc = "Information and dependencies needed to generate Go code from protos",
     fields = {
@@ -261,26 +285,4 @@ def go_proto_compiler(name, **kwargs):
         **kwargs
     )
 
-def _incompatible_toolchains_enabled():
-    return getattr(proto_common, "INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION", False)
 
-def _find_toolchain(ctx, legacy_attr, toolchain_type):
-    if _incompatible_toolchains_enabled():
-        toolchain = ctx.toolchains[toolchain_type]
-        if not toolchain:
-            fail("No toolchains registered for '%s'." % toolchain_type)
-        return toolchain.proto
-    else:
-        return getattr(ctx.attr, legacy_attr)[ProtoLangToolchainInfo]
-
-def _use_toolchain(toolchain_type):
-    if _incompatible_toolchains_enabled():
-        return [config_common.toolchain_type(toolchain_type, mandatory = False)]
-    else:
-        return []
-
-def _if_legacy_toolchain(legacy_attr_dict):
-    if _incompatible_toolchains_enabled():
-        return {}
-    else:
-        return legacy_attr_dict

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -18,6 +18,10 @@ load(
 )
 load("@com_google_protobuf//bazel/common:proto_common.bzl", "proto_common")
 load(
+    "@com_google_protobuf//bazel/common:proto_lang_toolchain_info.bzl",
+    "ProtoLangToolchainInfo",
+)
+load(
     "//go:def.bzl",
     "GoInfo",
     "go_context",
@@ -257,7 +261,6 @@ def go_proto_compiler(name, **kwargs):
         **kwargs
     )
 
-
 def _incompatible_toolchains_enabled():
     return getattr(proto_common, "INCOMPATIBLE_ENABLE_PROTO_TOOLCHAIN_RESOLUTION", False)
 
@@ -281,4 +284,3 @@ def _if_legacy_toolchain(legacy_attr_dict):
         return {}
     else:
         return legacy_attr_dict
-

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -17,7 +17,7 @@ load(
     "types",
 )
 load(
-    "@rules_proto//proto:defs.bzl",
+    "@com_google_protobuf//bazel/common:proto_info.bzl",
     "ProtoInfo",
 )
 load(

--- a/proto/gogo.bzl
+++ b/proto/gogo.bzl
@@ -20,7 +20,7 @@ def _gogo_special_proto_impl(ctx):
         "github.com/gogo/protobuf/gogoproto/gogo.proto",
     )
     ctx.file("github.com/gogo/protobuf/gogoproto/BUILD.bazel", """
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "gogoproto",

--- a/proto/private/toolchain.bzl
+++ b/proto/private/toolchain.bzl
@@ -16,7 +16,7 @@
 # compatibility with --noincompatible_enable_proto_toolchain_resolution.
 
 load(
-    "@rules_proto//proto:proto_common.bzl",
+    "@com_google_protobuf//bazel/common:proto_lang_toolchain_info.bzl",
     "ProtoLangToolchainInfo",
 )
 load(

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -73,7 +73,7 @@ rules_proto_toolchains()
 `,
 	Main: `
 -- BUILD.bazel --
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 

--- a/tests/core/cross/proto_test.go
+++ b/tests/core/cross/proto_test.go
@@ -22,7 +22,7 @@ import (
 
 var testArgs = bazel_testing.Args{
 	ModuleFileSuffix: `
-bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
 bazel_dep(name = "toolchains_protoc", version = "0.3.4")
 `,
 	WorkspacePrefix: `
@@ -45,31 +45,14 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    strip_prefix = "protobuf-21.7",
-    # latest available in BCR, as of 2022-09-30
+    integrity = "sha256-zl0At4RQoMpAC/NgrADA1ZnMIl8EnZhqJ+mk45bFqEo=",
+    strip_prefix = "protobuf-29.0-rc2",
     urls = [
-        "https://github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v21.7.tar.gz",
+        "https://github.com/protocolbuffers/protobuf/archive/v29.0-rc2.tar.gz",
+        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v29.0-rc2.tar.gz",
     ],
 )
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
-http_archive(
-    name = "rules_proto",
-    sha256 = "303e86e722a520f6f326a50b41cfc16b98fe6d1955ce46642a5b7a67c11c0f5d",
-    strip_prefix = "rules_proto-6.0.0",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.0/rules_proto-6.0.0.tar.gz",
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-rules_proto_dependencies()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-rules_proto_toolchains()
 `,
 	Main: `
 -- BUILD.bazel --

--- a/tests/core/go_proto_aspect/BUILD.bazel
+++ b/tests/core/go_proto_aspect/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load(":codegen.bzl", "go_generated_library")
 
 go_generated_library(

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 # Common rules
 proto_library(

--- a/tests/core/go_proto_library_importmap/BUILD.bazel
+++ b/tests/core/go_proto_library_importmap/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "foo_proto",

--- a/tests/core/go_proto_library_importpath/BUILD.bazel
+++ b/tests/core/go_proto_library_importpath/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 # Common rules
 proto_library(

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 -- BUILD.bazel --
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 go_binary(
     name = "main",

--- a/tests/core/transition/hermeticity_test.go
+++ b/tests/core/transition/hermeticity_test.go
@@ -122,8 +122,7 @@ message Foo {
 }
 `,
 		ModuleFileSuffix: `
-bazel_dep(name = "protobuf", version = "21.7", repo_name = "com_google_protobuf")
-bazel_dep(name = "rules_proto", version = "6.0.0")
+bazel_dep(name = "protobuf", version = "29.0-rc2", repo_name = "com_google_protobuf")
 bazel_dep(name = "toolchains_protoc", version = "0.3.4")
 `,
 		WorkspacePrefix: `
@@ -160,23 +159,6 @@ http_archive(
         "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v29.0-rc2.tar.gz",
     ],
 )
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
-http_archive(
-    name = "rules_proto",
-    sha256 = "0e5c64a2599a6e26c6a03d6162242d231ecc0de219534c38cb4402171def21e8",
-    strip_prefix = "rules_proto-7.0.2",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/7.0.2/rules_proto-7.0.2.tar.gz",
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-rules_proto_dependencies()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-rules_proto_toolchains()
 `,
 	})
 }

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "color_service_proto",

--- a/tests/integration/grpc_plugin/BUILD.bazel
+++ b/tests/integration/grpc_plugin/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "hello_proto",

--- a/tests/legacy/examples/proto/dep/BUILD.bazel
+++ b/tests/legacy/examples/proto/dep/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "useful_proto",

--- a/tests/legacy/examples/proto/embed/BUILD.bazel
+++ b/tests/legacy/examples/proto/embed/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "embed_proto",

--- a/tests/legacy/examples/proto/gogo/BUILD.bazel
+++ b/tests/legacy/examples/proto/gogo/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "values_proto",

--- a/tests/legacy/examples/proto/gostyle/BUILD.bazel
+++ b/tests/legacy/examples/proto/gostyle/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 genrule(
     name = "copy",

--- a/tests/legacy/examples/proto/grpc/BUILD.bazel
+++ b/tests/legacy/examples/proto/grpc/BUILD.bazel
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "my_svc_proto",

--- a/tests/legacy/examples/proto/lib/BUILD.bazel
+++ b/tests/legacy/examples/proto/lib/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "lib_proto",

--- a/tests/legacy/proto_ignore_go_package_option/BUILD.bazel
+++ b/tests/legacy/proto_ignore_go_package_option/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "a_proto",


### PR DESCRIPTION
**What type of PR is this?**

> Cleanup

**What does this PR do? Why is it needed?**

Replaces rules_proto uses with com_google_protobuf. The former is deprecated.