### PR TITLE
Disable `pkgfact` analyzer

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -101,7 +101,8 @@ _TOOLS_NOGO = [
     "@org_golang_x_tools//go/analysis/passes/lostcancel:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/nilfunc:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/nilness:go_default_library",
-    "@org_golang_x_tools//go/analysis/passes/pkgfact:go_default_library",
+    # demo only
+    # "@org_golang_x_tools//go/analysis/passes/pkgfact:go_default_library",
     "@org_golang_x_tools//go/analysis/passes/printf:go_default_library",
     # shadow analyzer is too noisy, see #4340
     # "@org_golang_x_tools//go/analysis/passes/shadow:go_default_library",


### PR DESCRIPTION
It's just a demo analyzer that serves as an example of the facts mechanism.

Context: https://bazelbuild.slack.com/archives/CDBP88Z0D/p1747334404309089?thread_ts=1747334404.309089&cid=CDBP88Z0D