### PR TITLE
Discourage references to the default SDK

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,8 @@ bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1", repo_name = "com_google
 bazel_dep(name = "rules_shell", version = "0.3.0")
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
+# Don't depend on this repo by name, use toolchains instead.
+# See https://github.com/bazel-contrib/rules_go/blob/master/go/toolchains.rst
 go_sdk.from_file(
     name = "go_default_sdk",
     go_mod = "//:go.mod",

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -45,10 +45,12 @@ go_sdk.nogo(
     nogo = "//:my_nogo",
 )
 
-# Bring the default SDK into scope to verify that it exists.
+# Don't depend on this repo by name, use toolchains instead.
+# See https://github.com/bazel-contrib/rules_go/blob/master/go/toolchains.rst.
 use_repo(go_sdk, "go_default_sdk")
 
-# Bring the selected host compatible SDK into scope to verify that it exists.
+# Don't depend on this repo by name, use toolchains instead.
+# See https://github.com/bazel-contrib/rules_go/blob/master/go/toolchains.rst
 use_repo(go_sdk, "go_host_compatible_sdk_label")
 
 go_deps = use_extension("@gazelle//:extensions.bzl", "go_deps")


### PR DESCRIPTION
The repo contains a host-compatible SDK and thus doesn't behave correctly in multi-platform builds.

Fixes #4342