### PR TITLE
Allow to exclude certain target from nogo facts collection

### DIFF
--- a/go/config/BUILD.bazel
+++ b/go/config/BUILD.bazel
@@ -96,9 +96,3 @@ bool_flag(
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
-
-bool_flag(
-    name = "unsafe_not_generate_nogo_facts_for_excludes",
-    build_setting_default = False,
-    visibility = ["//visibility:public"],
-)

--- a/go/config/BUILD.bazel
+++ b/go/config/BUILD.bazel
@@ -96,3 +96,9 @@ bool_flag(
     build_setting_default = False,
     visibility = ["//visibility:public"],
 )
+
+bool_flag(
+    name = "unsafe_not_generate_nogo_facts_for_excludes",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)

--- a/go/nogo.rst
+++ b/go/nogo.rst
@@ -77,13 +77,19 @@ instead.
     go_register_toolchains(version = "1.23.1")
     go_register_nogo(
       nogo = "@//:my_nogo"  # my_nogo is in the top-level BUILD file of this workspace
-      includes = ["@//:__subpackages__"],  # Labels to lint. By default only lints code in workspace.
-      excludes = ["@//generated:__subpackages__"],  # Labels to exclude.
+      excludes = ["@//generated:__subpackages__"],  # Labels to exclude from nogo facts collection. This is unsafe. See notes below.
     )
 
 **NOTE**: You must include ``"@//"`` prefix when referring to targets in the local
 workspace. Also note that you cannot use this to refer to bzlmod repos, as the labels
 don't go though repo mapping.
+
+Although nogo only reports errors in those files in `only_files` is specified for analyzers,
+it still collects facts from all targets in the transitive dependency closure, because it needs
+those facts to accurately reports the errors. However, this can be slow, especially in large Go packages,
+which could be generated. For performance reasons, users can exclude them with `excludes`.
+This is unsafe, and should only be used to exclude packages that don't provide
+useful nogo facts for the configured set of analyzers.
 
 The `nogo`_ rule will generate a program that executes all the supplied
 analyzers at build-time. The generated ``nogo`` program will run alongside the
@@ -278,6 +284,9 @@ contain the following key-value pairs:
 | Keys in ``exclude_files`` override keys in ``only_files``. If a .go file matches a key present   |
 | in both ``only_files`` and ``exclude_files``, the analyzer will not emit diagnostics for that    |
 | file.                                                                                            |
+| The key difference between ``excludes_files`` and ``excludes`` from ``go_register_nogo`` is that |
+| the former is used to exclude files from reporting errors, while the latter is to prevent        |
+| nogo from collecting facts from certain packages.                                                |
 +----------------------------+---------------------------------------------------------------------+
 | ``"analyzer_flags"``       | :type:`dictionary, string to string`                                |
 +----------------------------+---------------------------------------------------------------------+

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -14,7 +14,7 @@
 
 load(
     "//go/private:context.bzl",
-    "validate_nogo",
+    "get_nogo",
 )
 load(
     "//go/private:mode.bzl",
@@ -59,16 +59,13 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     out_export = go.declare_file(go, name = source.name, ext = pre_ext + ".x")
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
-    nogo = go.nogo
+    nogo = get_nogo(go)
 
     # nogo is a FilesToRunProvider and some targets don't have it, some have it but no executable.
     if nogo != None and nogo.executable != None:
         out_facts = go.declare_file(go, name = source.name, ext = pre_ext + ".facts")
         out_diagnostics = go.declare_directory(go, name = source.name, ext = pre_ext + "_nogo")
-        if validate_nogo(go):
-            out_nogo_validation = go.declare_file(go, name = source.name, ext = pre_ext + ".nogo")
-        else:
-            out_nogo_validation = None
+        out_nogo_validation = go.declare_file(go, name = source.name, ext = pre_ext + ".nogo")
     else:
         out_facts = None
         out_diagnostics = None

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -429,11 +429,13 @@ def _matches_scopes(label, scopes):
             return True
     return False
 
-def validate_nogo(go):
-    """Whether nogo should be run as a validation action rather than just to generate fact files for the current
-    target."""
+def get_nogo(go):
+    """Returns the nogo file for this target, if enabled and in scope."""
     label = go.label
-    return _matches_scopes(label, NOGO_INCLUDES) and not _matches_scopes(label, NOGO_EXCLUDES)
+    if not _matches_scopes(label, NOGO_EXCLUDES):
+        return go.nogo
+    else:
+        return None
 
 default_go_config_info = GoConfigInfo(
     static = False,

--- a/go/private/nogo.bzl
+++ b/go/private/nogo.bzl
@@ -34,13 +34,14 @@ def _go_register_nogo_impl(ctx):
         },
         executable = False,
     )
+    if ctx.attr.includes:
+        print("go_register_nogo's include attribute is no-op. Nogo now collect facts from all targets by default. To include files in nogo validation, please use only_files in the JSON: https://github.com/bazel-contrib/rules_go/blob/master/go/nogo.rst#example")
+
     ctx.file(
         "scope.bzl",
         """
-INCLUDES = {includes}
 EXCLUDES = {excludes}
 """.format(
-            includes = _scope_list_repr(ctx.attr.includes),
             excludes = _scope_list_repr(ctx.attr.excludes),
         ),
         executable = False,
@@ -55,14 +56,12 @@ go_register_nogo = repository_rule(
     _go_register_nogo_impl,
     attrs = {
         "nogo": attr.string(mandatory = True),
-        # Special sentinel value used to let nogo run on all targets when using
-        # WORKSPACE, for backwards compatibility.
-        "includes": attr.string_list(default = ["all"]),
+        "includes": attr.string_list(default = None),
         "excludes": attr.string_list(),
     },
 )
 
-def go_register_nogo_wrapper(nogo, includes = NOGO_DEFAULT_INCLUDES, excludes = NOGO_DEFAULT_EXCLUDES):
+def go_register_nogo_wrapper(nogo, includes = None, excludes = NOGO_DEFAULT_EXCLUDES):
     """See go/nogo.rst"""
     go_register_nogo(
         name = "io_bazel_rules_nogo",


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
After #4268, nogo collects facts from all targets. So `go_register_nogo`'s `includes` and `excludes` now overlap with the JSON config's `only_files` and `exclude_files`, which is to stop nogo from reporting errors in certain files/targets. Meanwhile, collecting facts can be slow for very large Go packages for some analyzers, slower than compilation. To address the performance issue, this PR revert `excludes` to its previous behavior: stop nogo from collecting facts from certain packages, while making `includes` of `go_register_nogo` a no-op with a warning message, asking people to use the JSON config instead. So nogo will continue to collect facts from all targets, which is the safe default, except those in `excludes`.

**Other notes for review**
To be backward-compatible, we can add a flag or attribute like `exclude_collect_facts`, but adding that on top of `excludes` and `exclude_files` makes hard to remember which is which.
