### PR TITLE
fix: Allow passing of environment variables to the compilation action.

### DIFF
--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -208,6 +208,7 @@ def emit_compilepkg(
         env = env,
         toolchain = GO_TOOLCHAIN_LABEL,
         execution_requirements = execution_requirements,
+        use_default_shell_env = True,
     )
 
     if have_nogo:


### PR DESCRIPTION
Implementation based on the comments in #3248, and tested locally with

  `VAR=foo bazel build -s --action_env=VAR //...`

and inspecting the output.

Fixes #2057