### PR TITLE
Allowing a go_proto_compiler to indicate whether it always generate files

### DIFF
--- a/go/tools/builders/protoc.go
+++ b/go/tools/builders/protoc.go
@@ -36,7 +36,7 @@ type genFileInfo struct {
 	created    bool         // Whether the file was created by protoc
 	from       *genFileInfo // The actual file protoc produced if not Path
 	unique     bool         // True if this base name is unique in expected results
-	ambiguous bool         // True if there were more than one possible outputs that matched this file
+	ambiguous  bool         // True if there were more than one possible outputs that matched this file
 }
 
 func run(args []string) error {
@@ -54,6 +54,7 @@ func run(args []string) error {
 	outPath := flags.String("out_path", "", "The base output path to write to.")
 	plugin := flags.String("plugin", "", "The go plugin to use.")
 	importpath := flags.String("importpath", "", "The importpath for the generated sources.")
+	strict := flags.Bool("strict", false, "whether to fail if any expected output file is not generated")
 	flags.Var(&options, "option", "The plugin options.")
 	flags.Var(&descriptors, "descriptor_set", "The descriptor set to read.")
 	flags.Var(&expected, "expected", "The expected output files.")
@@ -183,6 +184,9 @@ func run(args []string) error {
 	for _, f := range files {
 		switch {
 		case f.expected && !f.created:
+			if *strict {
+				return fmt.Errorf("file %q expected from plugin %q but not created", f.path, *plugin)
+			}
 			// Some plugins only create output files if the proto source files
 			// have relevant definitions (e.g., services for grpc_gateway). Create
 			// trivial files that the compiler will ignore for missing outputs.
@@ -206,6 +210,15 @@ func run(args []string) error {
 		if buf.Len() > 0 {
 			fmt.Fprintf(buf, "Check that the go_package option is %q.", *importpath)
 			return errors.New(buf.String())
+		}
+
+		if filepath.Ext(f.path) != ".go" {
+			continue
+		}
+		// Additionally check that created files are valid, because invalid Go file causes cache poisoning.
+		_, err := parser.ParseFile(token.NewFileSet(), f.path, nil, parser.PackageClauseOnly)
+		if err != nil {
+			return fmt.Errorf("plugin %q created an invalid Go file %q: %v", *plugin, f.path, err)
 		}
 	}
 

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -73,6 +73,7 @@ GOGO_VARIANTS = [
     name = variant + "_proto",
     options = GOGO_WELL_KNOWN_TYPE_REMAPS,
     plugin = "@com_github_gogo_protobuf//protoc-gen-" + variant,
+    always_generate = True,
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
@@ -86,6 +87,7 @@ GOGO_VARIANTS = [
 go_proto_compiler(
     name = "gofast_proto",
     plugin = "@com_github_gogo_protobuf//protoc-gen-gofast",
+    always_generate = True,
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",
@@ -96,6 +98,7 @@ go_proto_compiler(
     name = variant + "_grpc",
     options = ["plugins=grpc"] + GOGO_WELL_KNOWN_TYPE_REMAPS,
     plugin = "@com_github_gogo_protobuf//protoc-gen-" + variant,
+    always_generate = True,
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_gogo_protobuf//gogoproto:go_default_library",
@@ -114,6 +117,7 @@ go_proto_compiler(
     name = "gofast_grpc",
     options = ["plugins=grpc"],
     plugin = "@com_github_gogo_protobuf//protoc-gen-gofast",
+    always_generate = True,
     visibility = ["//visibility:public"],
     deps = [
         "@com_github_golang_protobuf//proto:go_default_library",

--- a/proto/compiler.bzl
+++ b/proto/compiler.bzl
@@ -94,6 +94,10 @@ compiler. Typically, these are Well Known Types and proto runtime libraries.""",
         "valid_archive": """A Boolean indicating whether the .go files produced
 by this compiler are buildable on their own. Compilers that just add methods
 to structs produced by other compilers will set this to False.""",
+        "always_generate": """A Boolean indicating whether this compiler 
+        always generate files, regardless of whether the proto files have 
+        relevant definitions (e.g., services for grpc_gateway). This allows
+        more strict check of compiler output.""",
         "internal": "Opaque value containing data used by compile.",
     },
 )
@@ -150,6 +154,8 @@ def go_proto_compile(go, compiler, protos, imports, importpath):
     args.add("-importpath", importpath)
     args.add("-out_path", outpath)
     args.add("-plugin", compiler.internal.plugin)
+    if compiler.always_generate:
+        args.add("-strict")
 
     # TODO(jayconrod): can we just use go.env instead?
     args.add_all(compiler.internal.options, before_each = "-option")
@@ -223,6 +229,7 @@ def _go_proto_compiler_impl(ctx):
             deps = ctx.attr.deps,
             compile = go_proto_compile,
             valid_archive = ctx.attr.valid_archive,
+            always_generate = ctx.attr.always_generate,
             internal = struct(
                 options = ctx.attr.options,
                 suffix = ctx.attr.suffix,
@@ -244,6 +251,10 @@ _go_proto_compiler = rule(
         "suffix": attr.string(default = ".pb.go"),
         "suffixes": attr.string_list(),
         "valid_archive": attr.bool(default = True),
+        "always_generate": attr.bool(
+            default = False,
+            doc = "indicates whether this proto compiler always generate files, regardless of whether the proto files have relevant definitions (e.g., services for grpc_gateway).",
+        ),
         "import_path_option": attr.bool(default = False),
         "plugin": attr.label(
             executable = True,


### PR DESCRIPTION
**What type of PR is this?**
Feature

**What does this PR do? Why is it needed?**
This PR allows a `go_proto_compiler` to  indicate whether it always generate files, if so, we can apply more strict check to the output of the proto compiler.

**Which issues(s) does this PR fix?**

This is an alternative way to fix #3949

**Other notes for review**
