### PR TITLE
fix: merge '-Wl,' with next value when

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -214,10 +214,21 @@ def _extract_extldflags(gc_linkopts, extldflags):
     """
     filtered_gc_linkopts = []
     is_extldflags = False
-    for opt in gc_linkopts:
+    skip_next = False
+
+    for i, opt in enumerate(gc_linkopts):
+        if skip_next:
+            skip_next = False
+            continue
+
         if is_extldflags:
+            if opt == "-Wl" and i + 1 < len(gc_linkopts):
+                # Merge '-Wl,' and next value
+                extldflags.append("-Wl," + gc_linkopts[i + 1])
+                skip_next = True
+            else:
+                extldflags.append(opt)
             is_extldflags = False
-            extldflags.append(opt)
         elif opt == "-extldflags":
             is_extldflags = True
         else:


### PR DESCRIPTION


**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

Previously if we pass `-extldflags,-Wl,--thread` into command line, it will only recognizes `-Wl` and ignores `--thread`. 

**Which issues(s) does this PR fix?**
#3921 

Fixes #

If we see `-Wl`, we can merge with next value in the list.

**Other notes for review**
