### PR TITLE
Fix breakages with Bazel@HEAD and incompatible flags

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -10,7 +10,7 @@ module(
 # conflicting with the real bazel_features repo.
 bazel_dep(name = "bazel_features", version = "1.9.1", repo_name = "io_bazel_rules_go_bazel_features")
 bazel_dep(name = "bazel_skylib", version = "1.2.0")
-bazel_dep(name = "platforms", version = "0.0.10")
+bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "rules_proto", version = "7.0.2")
 bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1", repo_name = "com_google_protobuf")
 bazel_dep(name = "rules_shell", version = "0.3.0")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,6 +16,7 @@ bazel_dep(name = "protobuf", version = "29.0-rc2.bcr.1", repo_name = "com_google
 bazel_dep(name = "rules_shell", version = "0.3.0")
 
 go_sdk = use_extension("//go:extensions.bzl", "go_sdk")
+
 # Don't depend on this repo by name, use toolchains instead.
 # See https://github.com/bazel-contrib/rules_go/blob/master/go/toolchains.rst
 go_sdk.from_file(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -66,6 +66,15 @@ go_register_nogo(
     nogo = "@//internal:nogo",
 )
 
+# Create the host platform repository transitively required by rules_go.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+	host_platform_repo,
+	name = "host_platform",
+)
+
 http_archive(
     name = "rules_proto",
     sha256 = "0e5c64a2599a6e26c6a03d6162242d231ecc0de219534c38cb4402171def21e8",

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,8 +71,8 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 load("@platforms//host:extension.bzl", "host_platform_repo")
 
 maybe(
-	host_platform_repo,
-	name = "host_platform",
+    host_platform_repo,
+    name = "host_platform",
 )
 
 http_archive(

--- a/go/private/repositories.bzl
+++ b/go/private/repositories.bzl
@@ -280,10 +280,10 @@ def go_rules_dependencies(force = False):
     wrapper(
         http_archive,
         name = "platforms",
-        sha256 = "218efe8ee736d26a3572663b374a253c012b716d8af0c07e842e82f238a0a7ee",
+        sha256 = "3384eb1c30762704fbe38e440204e114154086c8fc8a8c2e3e28441028c019a8",
         urls = [
-            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
-            "https://github.com/bazelbuild/platforms/releases/download/0.0.10/platforms-0.0.10.tar.gz",
+            "https://mirror.bazel.build/github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz",
+            "https://github.com/bazelbuild/platforms/releases/download/1.0.0/platforms-1.0.0.tar.gz",
         ],
     )
 

--- a/go/private/rules/go_bin_for_host.bzl
+++ b/go/private/rules/go_bin_for_host.bzl
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@local_config_platform//:constraints.bzl", "HOST_CONSTRAINTS")
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
 load("//go/private:common.bzl", "GO_TOOLCHAIN")
 
 def _ensure_target_cfg(ctx):

--- a/go/tools/bazel_benchmark/WORKSPACE.in
+++ b/go/tools/bazel_benchmark/WORKSPACE.in
@@ -17,6 +17,15 @@ go_rules_dependencies()
 
 go_register_toolchains(go_version = "host")
 
+# Create the host platform repository transitively required by rules_go.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+	host_platform_repo,
+	name = "host_platform",
+)
+
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
 
 gazelle_dependencies()

--- a/go/tools/bazel_testing/bazel_testing.go
+++ b/go/tools/bazel_testing/bazel_testing.go
@@ -543,6 +543,16 @@ go_register_nogo(
 	{{ end}}
 )
 {{end}}
+
+# Create the host platform repository transitively required by rules_go.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+	host_platform_repo,
+	name = "host_platform",
+)
+
 {{.Suffix}}
 `))
 

--- a/go/tools/releaser/boilerplate.go
+++ b/go/tools/releaser/boilerplate.go
@@ -41,7 +41,17 @@ load("@io_bazel_rules_go//go:deps.bzl", "go_register_toolchains", "go_rules_depe
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "%[3]s")`, version, shasum, goVersion)
+go_register_toolchains(version = "%[3]s")
+
+# Create the host platform repository transitively required by rules_go.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+	host_platform_repo,
+	name = "host_platform",
+)
+`, version, shasum, goVersion)
 }
 
 func findLatestGoVersion() (v string, err error) {

--- a/tests/bcr/BUILD.bazel
+++ b/tests/bcr/BUILD.bazel
@@ -7,6 +7,7 @@ load(
     "go_test",
     "nogo",
 )
+load("@rules_shell//shell:sh_test.bzl", "sh_test")
 load("//:transition.bzl", "sdk_transition_test")
 
 nogo(

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -20,6 +20,7 @@ local_path_override(
 
 bazel_dep(name = "gazelle", version = "0.33.0")
 bazel_dep(name = "protobuf", version = "3.19.6")
+bazel_dep(name = "rules_shell", version = "0.4.1")
 
 # Required with --incompatible_enable_proto_toolchain_resolution.
 # Avoids building protoc from source, which speeds up CI runs.

--- a/tests/bcr/proto/BUILD.bazel
+++ b/tests/bcr/proto/BUILD.bazel
@@ -1,5 +1,6 @@
 load("@my_rules_go//go:def.bzl", "go_test")
 load("@my_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
+load("@protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "foo_proto",

--- a/tests/core/go_proto_aspect/BUILD.bazel
+++ b/tests/core/go_proto_aspect/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load(":codegen.bzl", "go_generated_library")
 
 go_generated_library(

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 # Common rules
 proto_library(

--- a/tests/core/go_proto_library_importmap/BUILD.bazel
+++ b/tests/core/go_proto_library_importmap/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "foo_proto",

--- a/tests/core/go_proto_library_importpath/BUILD.bazel
+++ b/tests/core/go_proto_library_importpath/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 # Common rules
 proto_library(

--- a/tests/core/transitive_headers/a/BUILD.bazel
+++ b/tests/core/transitive_headers/a/BUILD.bazel
@@ -6,6 +6,6 @@ go_library(
         "a.go",
         "a.s",
     ],
-    deps = ["//tests/core/transitive_headers/b"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/transitive_headers/a",
+    deps = ["//tests/core/transitive_headers/b"],
 )

--- a/tests/core/transitive_headers/b/BUILD.bazel
+++ b/tests/core/transitive_headers/b/BUILD.bazel
@@ -6,7 +6,7 @@ go_library(
         "b.go",
         "b.h",
     ],
-    deps = ["//tests/core/transitive_headers/c"],
     importpath = "github.com/bazelbuild/rules_go/tests/core/transitive_headers/b",
     visibility = ["//visibility:public"],
+    deps = ["//tests/core/transitive_headers/c"],
 )

--- a/tests/integration/googleapis/BUILD.bazel
+++ b/tests/integration/googleapis/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "color_service_proto",

--- a/tests/integration/grpc_plugin/BUILD.bazel
+++ b/tests/integration/grpc_plugin/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "hello_proto",

--- a/tests/legacy/examples/proto/dep/BUILD.bazel
+++ b/tests/legacy/examples/proto/dep/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "useful_proto",

--- a/tests/legacy/examples/proto/embed/BUILD.bazel
+++ b/tests/legacy/examples/proto/embed/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "embed_proto",

--- a/tests/legacy/examples/proto/gogo/BUILD.bazel
+++ b/tests/legacy/examples/proto/gogo/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "values_proto",

--- a/tests/legacy/examples/proto/gostyle/BUILD.bazel
+++ b/tests/legacy/examples/proto/gostyle/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 genrule(
     name = "copy",

--- a/tests/legacy/examples/proto/grpc/BUILD.bazel
+++ b/tests/legacy/examples/proto/grpc/BUILD.bazel
@@ -1,6 +1,6 @@
+load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary")
 load("@io_bazel_rules_go//proto:def.bzl", "go_grpc_library", "go_proto_library")
-load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 
 proto_library(
     name = "my_svc_proto",

--- a/tests/legacy/examples/proto/lib/BUILD.bazel
+++ b/tests/legacy/examples/proto/lib/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "lib_proto",

--- a/tests/legacy/proto_ignore_go_package_option/BUILD.bazel
+++ b/tests/legacy/proto_ignore_go_package_option/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "a_proto",


### PR DESCRIPTION
**What type of PR is this?**

Adapt to a Bazel breaking change

**What does this PR do? Why is it needed?**

The `local_config_platform` repo is no longer available with Bazel@HEAD, so the host constraints have to be loaded from `@platforms//host`.

Also prepare the BCR test repo for Bazel@HEAD with `--incompatible_autoload_externally=` by applying buildifier lint fixes.

**Which issues(s) does this PR fix?**

**Other notes for review**
