### PR TITLE
Gracefully handle a panicking analyzer

### DIFF
--- a/go/tools/builders/nogo_main.go
+++ b/go/tools/builders/nogo_main.go
@@ -429,6 +429,12 @@ func (act *action) execOnce() {
 	act.pass = pass
 
 	var err error
+	defer func() {
+		if r := recover(); r != nil {
+			// If the analyzer panics, we catch it here and return an error.
+			act.err = fmt.Errorf("panic: %v", r)
+		}
+	}()
 	if !act.pkg.illTyped || pass.Analyzer.RunDespiteErrors {
 		act.result, err = pass.Analyzer.Run(pass)
 		if err == nil {


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

We previously didn't show any error when an analyzer panicked and Bazel would show a "mandatory output not created" error for the nogo action.

**Which issues(s) does this PR fix?**

**Other notes for review**
