### PR TITLE
Inherit `//go/config:static` and `//go/config:pure` as settings for a go_tool_transition.

### DIFF
--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -211,7 +211,7 @@ _stdlib_keep_keys = sorted([
     "//go/config:pgoprofile",
 ])
 
-_go_reset_transition_dict = dict(_common_reset_transition_dict)
+_go_reset_transition_dict = dict(_reset_transition_dict)
 _go_reset_transition_dict.pop("//go/config:static")
 _go_reset_transition_dict.pop("//go/config:pure")
 _go_reset_transition_keys = sorted(_go_reset_transition_dict.keys())

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -211,6 +211,11 @@ _stdlib_keep_keys = sorted([
     "//go/config:pgoprofile",
 ])
 
+_go_reset_transition_dict = dict(_common_reset_transition_dict)
+_go_reset_transition_dict.pop("//go/config:static")
+_go_reset_transition_dict.pop("//go/config:pure")
+_go_reset_transition_keys = sorted(_go_reset_transition_dict.keys())
+
 def _go_tool_transition_impl(settings, _attr):
     """Sets most Go settings to default values (use for external Go tools).
 
@@ -223,12 +228,12 @@ def _go_tool_transition_impl(settings, _attr):
     have `cfg = "exec"` so tool binaries should be built for the execution
     platform.
     """
-    return dict(settings, **_reset_transition_dict)
+    return dict(settings, **_go_reset_transition_dict)
 
 go_tool_transition = transition(
     implementation = _go_tool_transition_impl,
-    inputs = _reset_transition_keys,
-    outputs = _reset_transition_keys,
+    inputs = _go_reset_transition_keys,
+    outputs = _go_reset_transition_keys,
 )
 
 def _non_go_tool_transition_impl(settings, _attr):


### PR DESCRIPTION
<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

Enables NoGO to run in build chains where static linkage with MUSL-libc is specified

Discussed in the [bazel slack](https://bazelbuild.slack.com/archives/CDBP88Z0D/p1750086489848049)

**Which issues(s) does this PR fix?**

Fixes #4378

**Other notes for review**
