### PR TITLE
coverage: Don't panic if flag.CommandLine is reassigned

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -156,6 +156,7 @@ tasks:
       - "-//tests/core/cgo:generated_versioned_dylib_test"
       - "-//tests/core/coverage:coverage_test"
       - "-//tests/core/coverage:issue3017_test"
+      - "-//tests/core/coverage:reassign_flag_commandline_test"
       - "-//tests/core/go_binary:go_default_test"
       - "-//tests/core/go_path:go_path_test"
       - "-//tests/core/go_test:data_test"

--- a/go/tools/bzltestutil/lcov.go
+++ b/go/tools/bzltestutil/lcov.go
@@ -31,12 +31,15 @@ import (
 // Lock in the COVERAGE_DIR during test setup in case the test uses e.g. os.Clearenv.
 var coverageDir = os.Getenv("COVERAGE_DIR")
 
+// Also lock in the test flag set in case test overwrites it.
+var testFlags = flag.CommandLine
+
 // ConvertCoverToLcov converts the go coverprofile file coverage.dat.cover to
 // the expectedLcov format and stores it in coverage.dat, where it is picked up by
 // Bazel.
 // The conversion emits line and branch coverage, but not function coverage.
 func ConvertCoverToLcov() error {
-	inPath := flag.Lookup("test.coverprofile").Value.String()
+	inPath := testFlags.Lookup("test.coverprofile").Value.String()
 	in, err := os.Open(inPath)
 	if err != nil {
 		// This can happen if there are no tests and should not be an error.

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -32,3 +32,8 @@ go_bazel_test(
     name = "issue3017_test",
     srcs = ["issue3017_test.go"],
 )
+
+go_bazel_test(
+    name = "reassign_flag_commandline_test",
+    srcs = ["reassign_flag_commandline_test.go"],
+)

--- a/tests/core/coverage/reassign_flag_commandline_test.go
+++ b/tests/core/coverage/reassign_flag_commandline_test.go
@@ -1,0 +1,56 @@
+// Copyright 2025 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reassign_flag_commandline_test
+
+import (
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+// This test verifies that a test that reassigns flag.CommandLine
+// and does not restore the original value after the test finishes
+// does not cause 'bazel coverage' to panic.
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "go_default_test",
+    srcs = ["test.go"],
+)
+-- test.go --
+package main
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestReassign(t *testing.T) {
+	flag.CommandLine = flag.NewFlagSet("test", flag.ExitOnError)
+}
+`,
+	})
+}
+
+func Test(t *testing.T) {
+	if err := bazel_testing.RunBazel("coverage", "//:go_default_test"); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION

<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When run with `go test -cover`, the following test does not panic:

```
-- foo.go --
package foo

func foo() int {
	return 42
}
-- foo_test.go --
package foo

import (
	"flag"
	"testing"
)

func TestReassign(t *testing.T) {
	flag.CommandLine = flag.NewFlagSet("test", flag.ExitOnError)
	_ = foo()
}
```

However, with `bazel coverage`, it does panic:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x20 pc=0x100f8dbe4]

goroutine 1 [running]:
github.com/bazelbuild/rules_go/go/tools/bzltestutil.ConvertCoverToLcov()
        external/io_bazel_rules_go/go/tools/bzltestutil/lcov.go:39 +0x54
github.com/bazelbuild/rules_go/go/tools/bzltestutil.lcovAtExitHook()
        external/io_bazel_rules_go/go/tools/bzltestutil/lcov.go:181 +0x1c
github.com/bazelbuild/rules_go/go/tools/bzltestutil.LcovTestDeps.SetPanicOnExit0({{}, 0x18?}, 0x4b?)
        external/io_bazel_rules_go/go/tools/bzltestutil/lcov.go:175 +0x24
testing.(*M).after(0x1400007c280?)
        GOROOT/src/testing/testing.go:2374 +0x74
testing.(*M).Run(0x1400007c280)
        GOROOT/src/testing/testing.go:2185 +0x940
main.main()
        bazel-out/darwin_arm64-fastbuild/bin/go_default_test_/testmain.go:157 +0x7a4
```

The cause is that the test reassigned `flag.CommandLine`
and did not restore the original value.
While that's bad behavior, `go test` does not explode,
so neither should `bazel coverage`.

This change fixes the issue by grabbing a reference to
`flag.CommandLine` before the test runs.

**Which issues(s) does this PR fix?**

Fixes #4383
