### PR TITLE
chore(go_proto_library): Improve error message on incorrect use.

### DIFF
--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -73,7 +73,7 @@ def _go_proto_aspect_impl(_target, ctx):
         if not hasattr(attr, attr_name):
             fail("""While processing go_proto_library deps: {label}, which is a {kind} is missing the '{attr_name}' \
 attribute. go_proto_library deps are usually other go_proto_library targets. We recommend double-checking the deps \
-to make sure they're the right type. If this is intentional (for example you're developing a new rule) make sure if \
+to make sure they're the right type. If this is intentional (for example you're developing a new rule) make sure it \
 declares the \"{attr_name}\" attribute.""".format(
                 label = _target.label,
                 kind = ctx.rule.kind,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -69,6 +69,18 @@ def get_imports(attr, importpath):
 
 def _go_proto_aspect_impl(_target, ctx):
     attr = ctx.rule.attr
+    for attr_name in ["importpath", "_go_context_data"]:
+        if not hasattr(attr, attr_name):
+            fail("while processing go_proto_library deps: " +
+                 "{label}, which is a {kind} is missing the '{attr_name}' attribute. ".format(
+                     label = _target.label,
+                     kind = ctx.rule.kind,
+                     attr_name = attr_name,
+                 ) + "go_proto_library deps are usually other go_proto_library targets. " +
+                 "We recommend double-checking the deps to make sure they're the right type. " +
+                 "If this is intentional (for example you're developing a new rule) " +
+                 "make sure if declares the \"{0}\" attribute.".format(attr_name))
+
     go = go_context(
         ctx,
         attr,

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -71,15 +71,14 @@ def _go_proto_aspect_impl(_target, ctx):
     attr = ctx.rule.attr
     for attr_name in ["importpath", "_go_context_data"]:
         if not hasattr(attr, attr_name):
-            fail("while processing go_proto_library deps: " +
-                 "{label}, which is a {kind} is missing the '{attr_name}' attribute. ".format(
-                     label = _target.label,
-                     kind = ctx.rule.kind,
-                     attr_name = attr_name,
-                 ) + "go_proto_library deps are usually other go_proto_library targets. " +
-                 "We recommend double-checking the deps to make sure they're the right type. " +
-                 "If this is intentional (for example you're developing a new rule) " +
-                 "make sure if declares the \"{0}\" attribute.".format(attr_name))
+            fail("""While processing go_proto_library deps: {label}, which is a {kind} is missing the '{attr_name}' \
+attribute. go_proto_library deps are usually other go_proto_library targets. We recommend double-checking the deps \
+to make sure they're the right type. If this is intentional (for example you're developing a new rule) make sure if \
+declares the \"{attr_name}\" attribute.""".format(
+                label = _target.label,
+                kind = ctx.rule.kind,
+                attr_name = attr_name,
+            ))
 
     go = go_context(
         ctx,


### PR DESCRIPTION
**What type of PR is this?**

Other

**What does this PR do? Why is it needed?**
It's relatively common for users to add `proto_library` to the `deps` of go_proto_library. The resulting error message (which complains about a missing attribute) is rather confusing, so let's improve it a bit.

**Which issues(s) does this PR fix?**

somewhat arguably fixes #4069

**Other notes for review**
