### PR TITLE
Cleanup macro wrappers

### DIFF
--- a/go/def.bzl
+++ b/go/def.bzl
@@ -49,6 +49,7 @@ load(
 )
 load(
     "//go/private/rules:library.bzl",
+    _go_library = "go_library",
     _go_tool_library = "go_tool_library",
 )
 load(
@@ -64,14 +65,16 @@ load(
     _go_source = "go_source",
 )
 load(
+    "//go/private/rules:test.bzl",
+    _go_test = "go_test",
+)
+load(
     "//go/private/rules:transition.bzl",
     _go_reset_target = "go_reset_target",
 )
 load(
     "//go/private/rules:wrappers.bzl",
     _go_binary_macro = "go_binary_macro",
-    _go_library_macro = "go_library_macro",
-    _go_test_macro = "go_test_macro",
 )
 load(
     "//go/private/tools:path.bzl",
@@ -164,13 +167,13 @@ GoArchiveData = _GoArchiveData
 GoSDK = _GoSDK
 
 # See docs/go/core/rules.md#go_library for full documentation.
-go_library = _go_library_macro
+go_library = _go_library
 
 # See docs/go/core/rules.md#go_binary for full documentation.
 go_binary = _go_binary_macro
 
 # See docs/go/core/rules.md#go_test for full documentation.
-go_test = _go_test_macro
+go_test = _go_test
 
 # See docs/go/core/rules.md#go_test for full documentation.
 go_source = _go_source

--- a/go/private/rules/wrappers.bzl
+++ b/go/private/rules/wrappers.bzl
@@ -15,8 +15,6 @@
 load(
     "//go/private:mode.bzl",
     "LINKMODES_EXECUTABLE",
-    "LINKMODE_C_ARCHIVE",
-    "LINKMODE_C_SHARED",
     "LINKMODE_NORMAL",
 )
 load(
@@ -24,30 +22,11 @@ load(
     "go_binary",
     "go_non_executable_binary",
 )
-load(
-    "//go/private/rules:library.bzl",
-    "go_library",
-)
-load(
-    "//go/private/rules:test.bzl",
-    "go_test",
-)
 
 _SELECT_TYPE = type(select({"//conditions:default": ""}))
 
-def _cgo(name, kwargs):
-    if "objc" in kwargs:
-        fail("//{}:{}: the objc attribute has been removed. .m sources may be included in srcs or may be extracted into a separated objc_library listed in cdeps.".format(native.package_name(), name))
-
-def go_library_macro(name, **kwargs):
-    """See docs/go/core/rules.md#go_library for full documentation."""
-    _cgo(name, kwargs)
-    go_library(name = name, **kwargs)
-
 def go_binary_macro(name, **kwargs):
     """See docs/go/core/rules.md#go_binary for full documentation."""
-    _cgo(name, kwargs)
-
     if kwargs.get("goos") != None or kwargs.get("goarch") != None:
         for key, value in kwargs.items():
             if type(value) == _SELECT_TYPE:
@@ -64,18 +43,3 @@ def go_binary_macro(name, **kwargs):
         go_binary(name = name, **kwargs)
     else:
         go_non_executable_binary(name = name, **kwargs)
-
-    if kwargs.get("linkmode") in (LINKMODE_C_ARCHIVE, LINKMODE_C_SHARED):
-        # Create an alias to tell users of the `.cc` rule that it is deprecated.
-        native.alias(
-            name = "{}.cc".format(name),
-            actual = name,
-            visibility = ["//visibility:public"],
-            tags = ["manual"],
-            deprecation = "This target is deprecated and will be removed in the near future. Please depend on ':{}' directly.".format(name),
-        )
-
-def go_test_macro(name, **kwargs):
-    """See docs/go/core/rules.md#go_test for full documentation."""
-    _cgo(name, kwargs)
-    go_test(name = name, **kwargs)


### PR DESCRIPTION
**What type of PR is this?**
Cleanup

**What does this PR do? Why is it needed?**
The `_cgo` messaging was added in 2018-2019. The `native.alias` is from 2021. Users have had a few years to address these warnings.

**Which issues(s) does this PR fix?**

Fixes #

**Other notes for review**
