### PR TITLE
Compute rpath correctly with nested bazel modules

### DIFF
--- a/go/private/rpath.bzl
+++ b/go/private/rpath.bzl
@@ -17,7 +17,7 @@ load(
     "paths",
 )
 
-# TODO: Replace with the function from `bazel-skylib` when it's available.
+# TODO: Replace with a Bazel-provided function when it's available.
 # https://github.com/bazelbuild/bazel/issues/14307
 def _rlocation_path(ctx, file):
     """Returns the path relative to the runfiles directory."""

--- a/go/private/rpath.bzl
+++ b/go/private/rpath.bzl
@@ -39,13 +39,11 @@ def _rpath(go, library, executable = None):
     # 1. Where the executable is inside its own .runfiles directory.
     #  This is the case for generated libraries as well as remote builds.
     #   a) go back to the runfiles root from the executable file in .runfiles
-    executable_rloc = _rlocation_path(go._ctx, executable)
-    depth = executable_rloc.count("/")
+    depth = _rlocation_path(go._ctx, executable).count("/")
     back_to_root = paths.join(*([".."] * depth))
 
     #   b) then walk back to the library's dir within runfiles dir.
-    library_rloc = _rlocation_path(go._ctx, library)
-    rpaths.append(paths.join(origin, back_to_root, paths.dirname(library_rloc)))
+    rpaths.append(paths.join(origin, back_to_root, paths.dirname(_rlocation_path(go._ctx, library))))
 
     # 2. Where the executable is outside the .runfiles directory:
     #  This is the case for local pre-built libraries, as well as local

--- a/go/private/rpath.bzl
+++ b/go/private/rpath.bzl
@@ -18,7 +18,7 @@ load(
 )
 
 # TODO: Replace with the function from `bazel-skylib` when it's available.
-# https://github.com/bazelbuild/bazel-skylib/issues/303
+# https://github.com/bazelbuild/bazel/issues/14307
 def _rlocation_path(ctx, file):
     """Returns the path relative to the runfiles directory."""
     if file.short_path.startswith("../"):
@@ -40,12 +40,11 @@ def _rpath(go, library, executable = None):
     #  This is the case for generated libraries as well as remote builds.
     #   a) go back to the runfiles root from the executable file in .runfiles
     executable_rloc = _rlocation_path(go._ctx, executable)
-    library_rloc = _rlocation_path(go._ctx, library)
-
     depth = executable_rloc.count("/")
     back_to_root = paths.join(*([".."] * depth))
 
-    #   b) then walk back to the library's short path
+    #   b) then walk back to the library's dir within runfiles dir.
+    library_rloc = _rlocation_path(go._ctx, library)
     rpaths.append(paths.join(origin, back_to_root, paths.dirname(library_rloc)))
 
     # 2. Where the executable is outside the .runfiles directory:

--- a/tests/bcr/BUILD.bazel
+++ b/tests/bcr/BUILD.bazel
@@ -83,3 +83,20 @@ sdk_transition_test(
     binary = ":wrap_test",
     sdk_version = "1.23.6",
 )
+
+go_library(
+    name = "cgonested",
+    srcs = ["cgo_nestedmod.go"],
+    cdeps = [
+        "@other_module//:bar_shared",
+    ],
+    cgo = True,
+)
+
+go_test(
+    name = "cgonested_test",
+    srcs = ["cgo_nestedmod_test.go"],
+    embed = [":cgonested"],
+    # TODO: temporarily enabled only for linux.
+    target_compatible_with = ["@platforms//os:linux"],
+)

--- a/tests/bcr/cgo_nestedmod.go
+++ b/tests/bcr/cgo_nestedmod.go
@@ -1,0 +1,8 @@
+package cgonested
+
+// int bar();
+import "C"
+
+func Bar() int {
+	return int(C.bar())
+}

--- a/tests/bcr/cgo_nestedmod_test.go
+++ b/tests/bcr/cgo_nestedmod_test.go
@@ -1,0 +1,10 @@
+package cgonested
+
+import "testing"
+
+func TestBar(t *testing.T) {
+	want := 278
+	if got := Bar(); got != want {
+		t.Errorf("got %d ; want %d", got, want)
+	}
+}

--- a/tests/bcr/other_module/BUILD.bazel
+++ b/tests/bcr/other_module/BUILD.bazel
@@ -1,1 +1,14 @@
+package(default_visibility = ["//visibility:public"])
+
 exports_files(["bar.txt"])
+
+cc_binary(
+    name = "libbar_shared",
+    srcs = ["bar.c"],
+    linkshared = True,
+)
+
+cc_import(
+    name = "bar_shared",
+    shared_library = ":libbar_shared",
+)

--- a/tests/bcr/other_module/bar.c
+++ b/tests/bcr/other_module/bar.c
@@ -1,0 +1,5 @@
+#include <stdlib.h>
+
+int bar() {
+  return 278;
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

My company has a complicated, uncommon bazel set up with nested bazel modules. We also use cgo extensively and have many go tests and binaries that end up linking to shared C++ libraries generated via other bazel modules. When such go tests are run with rbe, they fail due to failure to locate the shared libraries within the runfiles directory.

On deeper investigation, I found that the existing `rpath` computation assumes that both the executable and the library are present within the working directory. In reality, the executable is present outside the working directory but within the runfiles directory.

Normalizing the paths with respect to the runfiles directory fixes the issue.

Relevant links:
- https://github.com/bazelbuild/bazel/issues/14307

**Other notes for review**

I added a test to verify that rpath computation works with nested modules. In fairness, this mainly guarantees that there's no regression in existing functionality as the test passes even without my fix. So far, I've not been able to produce a minimum example that showcases the problem.

Existing tests in tests/core/cgo also exercise rpath computation.