### PR TITLE
Request stdlib cache dir in gopackagesdriver

### DIFF
--- a/go/tools/gopackagesdriver/aspect.bzl
+++ b/go/tools/gopackagesdriver/aspect.bzl
@@ -65,6 +65,7 @@ def make_pkg_json(ctx, name, pkg_info):
 def _go_pkg_info_aspect_impl(target, ctx):
     # Fetch the stdlib JSON file from the inner most target
     stdlib_json_file = None
+    stdlib_cache_dir = None
 
     transitive_json_files = []
     transitive_export_files = []
@@ -87,6 +88,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
                 # Fetch the stdlib json from the first dependency
                 if not stdlib_json_file:
                     stdlib_json_file = pkg_info.stdlib_json_file
+                    stdlib_cache_dir = pkg_info.stdlib_cache_dir
 
     pkg_json_files = []
     compiled_go_files = []
@@ -113,9 +115,11 @@ def _go_pkg_info_aspect_impl(target, ctx):
     # current go_ node.
     if not stdlib_json_file:
         stdlib_json_file = ctx.attr._go_stdlib[GoStdLib]._list_json
+        stdlib_cache_dir = ctx.attr._go_stdlib[GoStdLib].cache_dir
 
     pkg_info = GoPkgInfo(
         stdlib_json_file = stdlib_json_file,
+        stdlib_cache_dir = stdlib_cache_dir,
         pkg_json_files = depset(
             direct = pkg_json_files,
             transitive = transitive_json_files,
@@ -137,6 +141,7 @@ def _go_pkg_info_aspect_impl(target, ctx):
             go_pkg_driver_srcs = pkg_info.compiled_go_files,
             go_pkg_driver_export_file = pkg_info.export_files,
             go_pkg_driver_stdlib_json_file = depset([pkg_info.stdlib_json_file] if pkg_info.stdlib_json_file else []),
+            go_pkg_driver_stdlib_cache_dir = pkg_info.stdlib_cache_dir or depset([]),
         ),
     ]
 

--- a/go/tools/gopackagesdriver/bazel_json_builder.go
+++ b/go/tools/gopackagesdriver/bazel_json_builder.go
@@ -159,7 +159,7 @@ func NewBazelJSONBuilder(bazel *Bazel, includeTests bool) (*BazelJSONBuilder, er
 }
 
 func (b *BazelJSONBuilder) outputGroupsForMode(mode packages.LoadMode) string {
-	og := "go_pkg_driver_json_file,go_pkg_driver_stdlib_json_file,go_pkg_driver_srcs"
+	og := "go_pkg_driver_json_file,go_pkg_driver_stdlib_json_file,go_pkg_driver_stdlib_cache_dir,go_pkg_driver_srcs"
 	if mode&packages.NeedExportsFile != 0 {
 		og += ",go_pkg_driver_export_file"
 	}


### PR DESCRIPTION


<!-- Thanks for sending a PR! Before submitting:

1. If this is your first PR, please read CONTRIBUTING.md and sign the CLA
   first. We cannot review code without a signed CLA.
2. Please file an issue *first*. All features and most bug fixes should have
   an associated issue with a design discussed and decided upon. Small bug
   fixes and documentation improvements don't need issues.
3. New features and bug fixes must have tests. Documentation may need to
   be updated. If you're unsure what to update, send the PR, and we'll discuss
   in review.
4. Note that PRs updating dependencies and new Go versions are not accepted.
   Please file an issue instead.
-->

**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The stdlib_json_file contains paths of compiled cgo files, which are in the stdlib cache_dir. The gopackagesdriver reads those files, but this dependency was not explicitly declared previously.

Usually, it works despite the missing dependency. But when you have a Bazel cache configured, and then run `bazel clean` and run the gopackagesdriver again, Bazel will not restore the cache_dir from the Bazel cache. The gopackagesdriver then fails with an error like this:

error: unable to load JSON files: unable to resolve imports: open [...]/bin/external/rules_go+/stdlib_/gocache/a4/a4f91e8314b27a4bce0e8fbc01bb9736cb9ed10da747af722c5a4f2fcb1213a3-d: no such file or directory

This change adds a new output group containing the stdlib cache_dir, and requests this from the gopackagesdriver, fixing the problem.