### PR TITLE
switch root_files from string_dict to string_keyed_label_dict

### DIFF
--- a/go/private/extensions.bzl
+++ b/go/private/extensions.bzl
@@ -104,7 +104,7 @@ _wrap_tag = tag_class(
             mandatory = False,
             doc = "A file in the SDK root directory. Use to determine GOROOT.",
         ),
-        "root_files": attr.string_dict(
+        "root_files": attr.string_keyed_label_dict(
             mandatory = False,
             doc = "A set of mappings from the host platform to a file in the SDK's root directory.",
         ),

--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -378,7 +378,7 @@ go_wrap_sdk_rule = repository_rule(
             mandatory = False,
             doc = "A file in the SDK root direcotry. Used to determine GOROOT.",
         ),
-        "root_files": attr.string_dict(
+        "root_files": attr.string_keyed_label_dict(
             mandatory = False,
             doc = "A set of mappings from the host platform to a file in the SDK's root directory",
         ),


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**
I'm trying to use an extension-generated repo as a wrapped sdk using `root_files`. I get a package load error similar to https://github.com/bazelbuild/bazel/issues/19301. 

**Which issues(s) does this PR fix?**
I saw in the comments (specifically https://github.com/bazelbuild/bazel/issues/19301#issuecomment-1694588371) that this would probably work if `root_files` used a `string_keyed_label_dict` and, when I tried it locally it did.

**Other notes for review**
