### PR TITLE
[go1.25 required] Install cmd/pack command if it's missing from pkg/tool

### DIFF
--- a/go/private/BUILD.sdk.bazel
+++ b/go/private/BUILD.sdk.bazel
@@ -28,7 +28,6 @@ filegroup(
         exclude = [
             "src/**/*_test.go",
             "src/**/testdata/**",
-            "src/cmd/**",
             # Only used by tests, cgo fails with linux before 3.17
             "src/crypto/internal/sysrand/internal/seccomp/**",
             "src/log/slog/internal/benchmarks/**",

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -200,6 +200,7 @@ def emit_compilepkg(
     go.actions.run(
         inputs = depset(inputs_direct, transitive = inputs_transitive),
         outputs = outputs,
+        tools = [go.toolchain.sdk.go],
         mnemonic = "GoCompilePkgExternal" if is_external_pkg else "GoCompilePkg",
         executable = go.toolchain._builder,
         arguments = ["compilepkg", shared_args, compile_args],

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -533,7 +533,7 @@ func compileGo(goenv *env, srcs []string, packagePath, importcfgPath, embedcfgPa
 
 func appendToArchive(goenv *env, outPath string, objFiles []string) error {
 	// Use abs to work around long path issues on Windows.
-	args := goenv.goTool("pack", "r", abs(outPath))
+	args := goenv.goCmd("tool", "pack", "r", abs(outPath))
 	args = append(args, objFiles...)
 	return goenv.runCommand(args)
 }


### PR DESCRIPTION
In go1.25 the "cmd/pack" command is no longer shipped with Go distributions, which results is build failures that look like
```
Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
2025-06-09 00:44:46 PDT
compilepkg: error running subcommand external/go_sdk/pkg/tool/linux_amd64/pack: fork/exec external/go_sdk/pkg/tool/linux_amd64/pack: no such file or directory
2025-06-09 00:44:46 PDT
ERROR: /home/testuser/.cache/bazel-single-base/external/io_nhooyr_websocket/BUILD.bazel:3:11: GoCompilePkg external/io_nhooyr_websocket/websocket.a failed: (Exit 1): builder failed: error executing GoCompilePkg command (from target @@io_nhooyr_websocket//:websocket) bazel-out/k8-opt-exec-ST-a828a81199fe/bin/external/go_sdk/builder_reset/builder compilepkg -sdk external/go_sdk -goroot bazel-out/k8-fastbuild/bin/external/io_bazel_rules_go/stdlib_ -installsuffix ... (remaining 63 arguments skipped)
```

Since the pack command is used to compile Go programs (in compilepkg.go) we need to build it from source.

ref: https://github.com/golang/go/issues/74080
fixes https://github.com/bazel-contrib/rules_go/issues/4398