### PR TITLE
Revert "go_sdk: store SDK filenames and hashes in lockfile facts"

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -81,7 +81,17 @@ def _go_download_sdk_impl(ctx):
             ctx.report_progress("Finding latest Go version")
         else:
             ctx.report_progress("Finding Go SHA-256 sums")
-        sdks_by_version = fetch_sdks_by_version(ctx)
+        ctx.download(
+            url = [
+                "https://go.dev/dl/?mode=json&include=all",
+                "https://golang.google.cn/dl/?mode=json&include=all",
+            ],
+            output = "versions.json",
+        )
+
+        data = ctx.read("versions.json")
+        ctx.delete("versions.json")
+        sdks_by_version = _parse_versions_json(data)
 
         if not version:
             highest_version = None
@@ -569,21 +579,6 @@ def _parse_versions_json(data):
         }
         for sdk in sdks
     }
-
-def fetch_sdks_by_version(ctx):
-    ctx.download(
-        url = [
-            "https://go.dev/dl/?mode=json&include=all",
-            "https://golang.google.cn/dl/?mode=json&include=all",
-        ],
-        output = "versions.json",
-    )
-    data = ctx.read("versions.json")
-
-    # module_ctx doesn't have delete, but its files are temporary anyway.
-    if hasattr(ctx, "delete"):
-        ctx.delete("versions.json")
-    return _parse_versions_json(data)
 
 def parse_version(version):
     """Parses a version string like "1.15.5" and returns a tuple of numbers or None"""

--- a/tests/bcr/MODULE.bazel
+++ b/tests/bcr/MODULE.bazel
@@ -19,7 +19,6 @@ local_path_override(
 )
 
 bazel_dep(name = "gazelle", version = "0.33.0")
-bazel_dep(name = "platforms", version = "1.0.0")
 bazel_dep(name = "protobuf", version = "3.19.6")
 bazel_dep(name = "rules_shell", version = "0.4.1")
 

--- a/tests/bcr/other_module/MODULE.bazel
+++ b/tests/bcr/other_module/MODULE.bazel
@@ -3,3 +3,7 @@ module(name = "other_module")
 bazel_dep(name = "rules_go", version = "")
 
 go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk")
+
+# Request an invalid SDK to verify that it isn't fetched since the test module registers a toolchain
+# that takes precedence.
+go_sdk.download(version = "3.0.0")


### PR DESCRIPTION
Reverts bazel-contrib/rules_go#4393

The facts feature didn't get merged in time for Bazel 8.4.0 and without it this PR caused an eager fetch of the version list for the default SDK.