### PR TITLE
Include blackbox tests in compilation_outputs group

### DIFF
--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -216,7 +216,10 @@ def _go_test_impl(ctx):
             executable = executable,
         ),
         OutputGroupInfo(
-            compilation_outputs = [internal_archive.data.file],
+            compilation_outputs = [
+                internal_archive.data.file,
+                external_archive.data.file,
+            ],
             nogo_fix = nogo_diagnosticss,
             _validation = validation_outputs,
         ),

--- a/tests/core/output_groups/BUILD.bazel
+++ b/tests/core/output_groups/BUILD.bazel
@@ -8,7 +8,10 @@ go_library(
 
 go_test(
     name = "lib_test",
-    srcs = ["lib_test.go"],
+    srcs = [
+        "lib_blackbox_test.go",
+        "lib_test.go",
+    ],
     embed = [":lib"],
 )
 

--- a/tests/core/output_groups/compilation_outputs_test.go
+++ b/tests/core/output_groups/compilation_outputs_test.go
@@ -25,9 +25,10 @@ func TestCompilationOutputs(t *testing.T) {
 		"compilation_outputs_test" + exe:                   true, // test binary; not relevant
 		"compilation_outputs_test" + exe + ".repo_mapping": true, // test binary repo mapping; not relevant
 
-		"lib.a":               false, // :lib archive
-		"lib_test.internal.a": false, // :lib_test archive
-		"bin.a":               false, // :bin archive
+		"lib.a":                    false, // :lib archive
+		"lib_test.internal.a":      false, // :lib_test internal archive
+		"lib_test_test.external.a": false, // :lib_test external archive
+		"bin.a":                    false, // :bin archive
 	}
 	for _, rf := range runfiles {
 		info, err := os.Stat(rf.Path)

--- a/tests/core/output_groups/lib_blackbox_test.go
+++ b/tests/core/output_groups/lib_blackbox_test.go
@@ -1,0 +1,1 @@
+package lib_test


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

The PR makes external test archive included in `compilation_outputs` output group. This is necessary because currently, e.g., `bazel build --output_groups=compilation_outputs //foo/bar:bar_test` won't build test files that have `package bar_test` in them.

**Other notes for review**

[Slack context](https://bazelbuild.slack.com/archives/CDBP88Z0D/p1756742089621919)
