### PR TITLE
Revert unnecessary test change

### DIFF
--- a/tests/core/go_binary/BUILD.bazel
+++ b/tests/core/go_binary/BUILD.bazel
@@ -48,7 +48,6 @@ go_binary(
     ],
     goarch = "amd64",
     goos = "plan9",
-    pure = "on",
 )
 
 many_deps(name = "many_deps")


### PR DESCRIPTION
This was included in 8286eae655d83412d11169ea707592cf0c0979b3, but turned out not to be necessary.
