### PR TITLE
Allow environment variables to override `go_env` in `@rules_go//go`

### DIFF
--- a/go/tools/go_bin_runner/main.go
+++ b/go/tools/go_bin_runner/main.go
@@ -128,10 +128,11 @@ func parseConfig() (Config, error) {
 }
 
 func getGoEnv(goBin string, cfg Config) ([]string, error) {
-	env := os.Environ()
+	var env []string
 	for k, v := range cfg.GoEnv {
 		env = append(env, k+"="+v)
 	}
+	env = append(env, os.Environ()...)
 
 	// The go binary lies at $GOROOT/bin/go.
 	goRoot, err := filepath.Abs(filepath.Dir(filepath.Dir(goBin)))

--- a/tests/bcr/go_tool_test.sh
+++ b/tests/bcr/go_tool_test.sh
@@ -18,3 +18,5 @@ runfiles_export_envvars
 export BUILD_WORKING_DIRECTORY=$(pwd)
 [[ "$("$GO_TOOL" version)" =~ ^go ]]
 [[ "$("$GO_TOOL" env GOPRIVATE)" == example.com ]]
+# Test that explicit env vars override `go_env` settings.
+[[ "$(GOPRIVATE=foo.com "$GO_TOOL" env GOPRIVATE)" == foo.com ]]


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

This PR fixes an inconsistency in how environment variables interact with `go_env`. Prior to this PR, environment variables could override settings in `go_env` within `go_repository`, but could not override `go_env` when invoking `@rules_go//go`.

**Which issues(s) does this PR fix?**

Fixes #4462

**Other notes for review**
