### PR TITLE
Fix pure mode detection for special rules

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -16,10 +16,14 @@ http_archive(
 # The non-polyfill version of this is needed by rules_proto below.
 http_archive(
     name = "bazel_features",
-    sha256 = "d7787da289a7fb497352211ad200ec9f698822a9e0757a4976fd9f713ff372b3",
-    strip_prefix = "bazel_features-1.9.1",
-    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.9.1/bazel_features-v1.9.1.tar.gz",
+    sha256 = "9390b391a68d3b24aef7966bce8556d28003fe3f022a5008efc7807e8acaaf1a",
+    strip_prefix = "bazel_features-1.36.0",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.36.0/bazel_features-v1.36.0.tar.gz",
 )
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
 
 # Required by protobuf and for //go/private:context.
 http_archive(
@@ -44,10 +48,6 @@ load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_jav
 rules_java_dependencies()
 
 rules_java_toolchains()
-
-load("@bazel_features//:deps.bzl", "bazel_features_deps")
-
-bazel_features_deps()
 
 go_rules_dependencies()
 
@@ -344,4 +344,11 @@ zig_toolchains(
         "macos-x86_64": "0c89e5d934ecbf9f4d2dea6e3b8dfcc548a3d4184a856178b3db74e361031a2b",
     },
     version = "0.11.0-dev.3886+0c1bfe271",
+)
+
+http_archive(
+    name = "with_cfg.bzl",
+    sha256 = "4da2d80d55c7013e52539b0e100f8f8465142cd05757aaecb3ddca962d735c05",
+    strip_prefix = "with_cfg.bzl-0.11.1",
+    url = "https://github.com/fmeum/with_cfg.bzl/releases/download/v0.11.1/with_cfg.bzl-v0.11.1.tar.gz",
 )

--- a/go/private/rules/nogo.bzl
+++ b/go/private/rules/nogo.bzl
@@ -18,6 +18,9 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "CGO_ATTRS",
+    "CGO_FRAGMENTS",
+    "CGO_TOOLCHAINS",
     "go_context",
     "new_go_info",
 )
@@ -108,8 +111,9 @@ _nogo = rule(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
-    },
-    toolchains = [GO_TOOLCHAIN],
+    } | CGO_ATTRS,
+    fragments = CGO_FRAGMENTS,
+    toolchains = [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
     cfg = go_tool_transition,
 )
 

--- a/go/private/rules/stdlib.bzl
+++ b/go/private/rules/stdlib.bzl
@@ -18,6 +18,9 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "CGO_ATTRS",
+    "CGO_FRAGMENTS",
+    "CGO_TOOLCHAINS",
     "go_context",
 )
 load(
@@ -45,8 +48,9 @@ stdlib = rule(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
-    },
+    } | CGO_ATTRS,
     doc = """stdlib builds the standard library for the target configuration
 or uses the precompiled standard library from the SDK if it is suitable.""",
-    toolchains = [GO_TOOLCHAIN],
+    fragments = CGO_FRAGMENTS,
+    toolchains = [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
 )

--- a/proto/def.bzl
+++ b/proto/def.bzl
@@ -31,6 +31,9 @@ load(
 )
 load(
     "//go/private:context.bzl",
+    "CGO_ATTRS",
+    "CGO_FRAGMENTS",
+    "CGO_TOOLCHAINS",
     "new_go_info",
 )
 load(
@@ -206,8 +209,9 @@ go_proto_library = rule(
         "_allowlist_function_transition": attr.label(
             default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
-    },
-    toolchains = [GO_TOOLCHAIN],
+    } | CGO_ATTRS,
+    fragments = CGO_FRAGMENTS,
+    toolchains = [GO_TOOLCHAIN] + CGO_TOOLCHAINS,
 )
 # go_proto_library is a rule that takes a proto_library (in the proto
 # attribute) and produces a go library for it.

--- a/tests/core/go_proto_library/BUILD.bazel
+++ b/tests/core/go_proto_library/BUILD.bazel
@@ -1,6 +1,7 @@
 load("@com_google_protobuf//bazel:proto_library.bzl", "proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+load(":defs.bzl", "host_platform_go_proto_library")
 
 # Common rules
 proto_library(
@@ -22,6 +23,14 @@ proto_library(
 
 go_proto_library(
     name = "bar_go_proto",
+    importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/bar",
+    proto = ":bar_proto",
+    deps = [":foo_go_proto"],
+)
+
+# Regression test for #4447
+host_platform_go_proto_library(
+    name = "host_bar_go_proto",
     importpath = "github.com/bazelbuild/rules_go/tests/core/go_proto_library/bar",
     proto = ":bar_proto",
     deps = [":foo_go_proto"],

--- a/tests/core/go_proto_library/defs.bzl
+++ b/tests/core/go_proto_library/defs.bzl
@@ -1,0 +1,26 @@
+load("@platforms//host:constraints.bzl", "HOST_CONSTRAINTS")
+load("@with_cfg.bzl", "with_cfg")
+load("//proto:def.bzl", "go_proto_library")
+
+def get_os():
+    for c in HOST_CONSTRAINTS:
+        if c.startswith("@platforms//os:"):
+            return {
+                "linux": "linux",
+                "osx": "darwin",
+                "windows": "windows",
+            }[c.split(":")[-1]]
+
+def get_cpu():
+    for c in HOST_CONSTRAINTS:
+        if c.startswith("@platforms//cpu:"):
+            return {
+                "x86_64": "amd64",
+                "aarch64": "arm64",
+            }[c.split(":")[-1]]
+
+host_platform_go_proto_library, _host_platform_go_proto_library = (
+    with_cfg(go_proto_library)
+        .set("host_platform", Label("@io_bazel_rules_go//go/toolchain:{}_{}".format(get_os(), get_cpu())))
+        .build()
+)


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`go_proto_library`, `nogo`, and `stdlib` may use cgo and thus need the relevant attributes to detect the availability of a C++ toolchain.

**Which issues(s) does this PR fix?**

Fixes #4447

**Other notes for review**
