### PR TITLE
Add GOARM64 platform constraints

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -121,6 +121,33 @@ go_config(
         "//go/constraints/arm:7": "7",
         "//conditions:default": None,
     }),
+    arm64 = select({
+        "//go/constraints/arm64:v8.1": "v8.1",
+        "//go/constraints/arm64:v8.2": "v8.2",
+        "//go/constraints/arm64:v8.3": "v8.3",
+        "//go/constraints/arm64:v8.4": "v8.4",
+        "//go/constraints/arm64:v8.5": "v8.5",
+        "//go/constraints/arm64:v8.6": "v8.6",
+        "//go/constraints/arm64:v8.7": "v8.7",
+        "//go/constraints/arm64:v8.8": "v8.8",
+        "//go/constraints/arm64:v8.9": "v8.9",
+        "//go/constraints/arm64:v9.0": "v9.0",
+        "//go/constraints/arm64:v9.1": "v9.1",
+        "//go/constraints/arm64:v9.2": "v9.2",
+        "//go/constraints/arm64:v9.3": "v9.3",
+        "//go/constraints/arm64:v9.4": "v9.4",
+        "//go/constraints/arm64:v9.5": "v9.5",
+        # The default is v8.0.
+        "//conditions:default": None,
+    }),
+    arm64_crypto = select({
+        "//go/constraints/arm64:crypto_on": True,
+        "//conditions:default": False,
+    }),
+    arm64_lse = select({
+        "//go/constraints/arm64:lse_on": True,
+        "//conditions:default": False,
+    }),
     cover_format = "//go/config:cover_format",
     # Always include debug symbols with -c dbg.
     debug = select({

--- a/go/BUILD.bazel
+++ b/go/BUILD.bazel
@@ -18,6 +18,7 @@ filegroup(
         "//go/config:all_files",
         "//go/constraints/amd64:all_files",
         "//go/constraints/arm:all_files",
+        "//go/constraints/arm64:all_files",
         "//go/platform:all_files",
         "//go/private:all_files",
         "//go/runfiles:all_files",

--- a/go/constraints/arm64/BUILD.bazel
+++ b/go/constraints/arm64/BUILD.bazel
@@ -1,0 +1,118 @@
+package(
+    default_visibility = ["//visibility:public"],
+)
+
+# Represents the level of support for the particular microarchitecture of a
+# target platform based on the general arm64 architecture.
+# GOARM64 is set based on the chosen constraint_value.
+# See https://go.dev/wiki/MinimumRequirements#arm64
+constraint_setting(
+    name = "arm64",
+)
+
+constraint_value(
+    name = "v8.0",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.1",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.2",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.3",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.4",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.5",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.6",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.7",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.8",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v8.9",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v9.0",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v9.1",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v9.2",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v9.3",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v9.4",
+    constraint_setting = ":arm64",
+)
+
+constraint_value(
+    name = "v9.5",
+    constraint_setting = ":arm64",
+)
+
+# Optional ARM64 CPU feature extensions, orthogonal to the version above.
+# These are appended to GOARM64, e.g. "v9.0,lse,crypto".
+constraint_setting(
+    name = "lse",
+)
+
+constraint_value(
+    name = "lse_on",
+    constraint_setting = ":lse",
+)
+
+constraint_setting(
+    name = "crypto",
+)
+
+constraint_value(
+    name = "crypto_on",
+    constraint_setting = ":crypto",
+)
+
+filegroup(
+    name = "all_files",
+    testonly = True,
+    srcs = glob(["**"]),
+    visibility = ["//visibility:public"],
+)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -472,6 +472,9 @@ default_go_config_info = GoConfigInfo(
     gc_goopts = [],
     amd64 = None,
     arm = None,
+    arm64 = None,
+    arm64_lse = False,
+    arm64_crypto = False,
     pgoprofile = None,
     export_stdlib = False,
 )
@@ -593,6 +596,16 @@ def go_context(
     # See https://go.dev/wiki/MinimumRequirements#arm
     if mode.arm:
         env["GOARM"] = mode.arm
+
+    # Similarly, set GOARM64 based on platform constraints in //go/constraints/arm64.
+    # See https://go.dev/wiki/MinimumRequirements#arm64
+    if mode.arm64:
+        arm64_val = mode.arm64
+        if mode.arm64_lse:
+            arm64_val += ",lse"
+        if mode.arm64_crypto:
+            arm64_val += ",crypto"
+        env["GOARM64"] = arm64_val
 
     if cgo_context_info:
         env.update(cgo_context_info.env)
@@ -1031,6 +1044,9 @@ def _go_config_impl(ctx):
         gc_goopts = ctx.attr.gc_goopts[BuildSettingInfo].value,
         amd64 = ctx.attr.amd64,
         arm = ctx.attr.arm,
+        arm64 = ctx.attr.arm64,
+        arm64_lse = ctx.attr.arm64_lse,
+        arm64_crypto = ctx.attr.arm64_crypto,
         pgoprofile = pgoprofile,
         export_stdlib = ctx.attr.export_stdlib[BuildSettingInfo].value,
     )
@@ -1085,6 +1101,9 @@ go_config = rule(
         ),
         "amd64": attr.string(),
         "arm": attr.string(),
+        "arm64": attr.string(),
+        "arm64_lse": attr.bool(),
+        "arm64_crypto": attr.bool(),
         "pgoprofile": attr.label(
             mandatory = True,
             allow_files = True,


### PR DESCRIPTION
 See https://go.dev/wiki/MinimumRequirements#arm64 for which options are surfaced in this PR.                                                                       
   
  **What type of PR is this?**                                                                                                                                       
                                                                                                                                                                   
  Feature                                                                                                                                                          
                                                                                                                                                        
  **What does this PR do? Why is it needed?**

  Adds support for the `GOARM64` environment variable via platform constraints, following the same pattern as the existing `GOAMD64` and `GOARM` support.

  New constraint settings under `//go/constraints/arm64`:
  - **Version**: `v8.0`–`v8.9`, `v9.0`–`v9.5` (defaults to `v8.0` when unset)
  - **Extensions**: `lse` and `crypto` (independent boolean constraint settings)

  These are combined into the `GOARM64` env var at build time, e.g. `GOARM64=v9.0,lse,crypto`.

  Usage example:
  ```starlark
  platform(
      name = "my_arm64_platform",
      constraint_values = [
          "@platforms//cpu:aarch64",
          "@platforms//os:linux",
          "//go/constraints/arm64:v9.0",
          "//go/constraints/arm64:lse_on",
          "//go/constraints/arm64:crypto_on",
      ],
  )
```

  Which issues(s) does this PR fix?

  Fixes https://github.com/bazel-contrib/rules_go/issues/4556

  Other notes for review

  The implementation mirrors the existing amd64/arm pattern:
  - go/constraints/arm64/BUILD.bazel — new constraint settings and values
  - BUILD.bazel — go_config wired up with select() for version, lse, and crypto
  - go/private/context.bzl — GoConfigInfo fields, go_config rule attrs, and GOARM64 env var construction