### PR TITLE
coverage: emit a real baseline for packages with no tests

### DIFF
--- a/go/private/actions/BUILD.bazel
+++ b/go/private/actions/BUILD.bazel
@@ -27,6 +27,16 @@ bzl_library(
 )
 
 bzl_library(
+    name = "baseline_coverage",
+    srcs = ["baseline_coverage.bzl"],
+    visibility = ["//go:__subpackages__"],
+    deps = [
+        "//go/private:common",
+        "@io_bazel_rules_go_bazel_features//:features",
+    ],
+)
+
+bzl_library(
     name = "binary",
     srcs = ["binary.bzl"],
     visibility = ["//go:__subpackages__"],

--- a/go/private/actions/baseline_coverage.bzl
+++ b/go/private/actions/baseline_coverage.bzl
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
-load("//go/private:common.bzl", "GO_TOOLCHAIN_LABEL")
+load("//go/private:common.bzl", "GO_TOOLCHAIN_LABEL", "SUPPORTS_PATH_MAPPING_REQUIREMENT")
 
 def baseline_coverage_kwargs(go, ctx, sources):
     """Emits a baseline coverage report and returns it as instrumented_files_info kwargs.
@@ -71,5 +71,11 @@ def _emit_baseline_coverage(go, *, sources, out_lcov):
         mnemonic = "GoBaselineCoverage",
         executable = go.toolchain._builder,
         arguments = ["baselinecoverage", args],
+        # The environment carries GOOS, GOARCH and CGO_ENABLED, which decide
+        # which sources the build constraints select. GOROOT is dropped and
+        # passed as an argument by builder_args instead, since path mapping
+        # cannot map environment variable values.
+        env = go.env_for_path_mapping,
+        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT,
         toolchain = GO_TOOLCHAIN_LABEL,
     )

--- a/go/private/actions/baseline_coverage.bzl
+++ b/go/private/actions/baseline_coverage.bzl
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
-load("//go/private:common.bzl", "GO_TOOLCHAIN_LABEL", "SUPPORTS_PATH_MAPPING_REQUIREMENT")
+load("//go/private:common.bzl", "GO_TOOLCHAIN_LABEL")
+load("//go/private/actions:utils.bzl", "path_mapping_action_settings")
 
 def baseline_coverage_kwargs(go, ctx, sources):
     """Emits a baseline coverage report and returns it as instrumented_files_info kwargs.
@@ -77,16 +78,10 @@ def _emit_baseline_coverage(go, ctx, *, sources, out_lcov):
     # separate record instead of being displaced by measured data. Path mapping
     # rewrites the paths of generated sources, so it can only be enabled where
     # compilepkg also enables it. See the matching condition there.
-    if getattr(ctx.attr, "cgo", False) or "local" in ctx.attr.tags:
-        env = go.env
-        execution_requirements = {}
-    else:
-        # The environment carries GOOS, GOARCH and CGO_ENABLED, which decide
-        # which sources the build constraints select. GOROOT is dropped and
-        # passed as an argument by builder_args instead, since path mapping
-        # cannot map environment variable values.
-        env = go.env_for_path_mapping
-        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT
+    env, execution_requirements = path_mapping_action_settings(
+        go,
+        getattr(ctx.attr, "cgo", False),
+    )
 
     go.actions.run(
         inputs = depset(go_srcs + [go.toolchain._covdata], transitive = [sdk.headers, sdk.tools]),

--- a/go/private/actions/baseline_coverage.bzl
+++ b/go/private/actions/baseline_coverage.bzl
@@ -44,6 +44,10 @@ def baseline_coverage_kwargs(go, ctx, sources):
         return {}
     if not go.coverage_enabled or not go.coverage_instrumented:
         return {}
+    if not go.toolchain._covdata:
+        # A custom toolchain without a covdata tool cannot decode the coverage
+        # meta-data this action's cover invocation emits.
+        return {}
 
     out_lcov = go.declare_file(go, name = ctx.label.name, ext = ".baseline.lcov")
     _emit_baseline_coverage(go, ctx, sources = sources, out_lcov = out_lcov)
@@ -64,6 +68,8 @@ def _emit_baseline_coverage(go, ctx, *, sources, out_lcov):
 
     args = go.builder_args(go)
     args.add_all(go_srcs, before_each = "-src")
+    args.add("-covdata", go.toolchain._covdata)
+    args.add("-importpath", go.importpath)
     args.add("-o", out_lcov)
 
     # The source paths this action writes to the tracefile have to be the same
@@ -83,7 +89,7 @@ def _emit_baseline_coverage(go, ctx, *, sources, out_lcov):
         execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT
 
     go.actions.run(
-        inputs = depset(go_srcs, transitive = [sdk.headers, sdk.tools]),
+        inputs = depset(go_srcs + [go.toolchain._covdata], transitive = [sdk.headers, sdk.tools]),
         outputs = [out_lcov],
         mnemonic = "GoBaselineCoverage",
         executable = go.toolchain._builder,

--- a/go/private/actions/baseline_coverage.bzl
+++ b/go/private/actions/baseline_coverage.bzl
@@ -1,0 +1,75 @@
+# Copyright 2026 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
+load("//go/private:common.bzl", "GO_TOOLCHAIN_LABEL")
+
+def baseline_coverage_kwargs(go, ctx, sources):
+    """Emits a baseline coverage report and returns it as instrumented_files_info kwargs.
+
+    Bazel asks a non-test rule for a "baseline" coverage report so that code no
+    test ever links still appears in the combined coverage report. Absent one,
+    Bazel substitutes a stub that names each source file and nothing else, which
+    its LcovPrinter renders as "LF:0/LH:0". A consumer cannot tell that apart
+    from a file with genuinely nothing to cover, so a wholly untested package
+    reports 100% rather than 0%.
+    See https://github.com/bazelbuild/bazel/issues/5716.
+
+    Returns empty kwargs, leaving Bazel's stub in place, when the running Bazel
+    is too old to accept a baseline, when the build is not collecting coverage,
+    or when --instrumentation_filter excludes this target. Nothing is emitted on
+    an ordinary build.
+
+    Args:
+        go: the Go context.
+        ctx: the rule context.
+        sources: the rule's `srcs`, matching what is declared to
+            coverage_common.instrumented_files_info as source attributes.
+
+    Returns:
+        A dict to splat into coverage_common.instrumented_files_info.
+    """
+    if not bazel_features.rules.instrumented_files_info_has_baseline_coverage_files:
+        return {}
+    if not go.coverage_enabled or not go.coverage_instrumented:
+        return {}
+
+    out_lcov = go.declare_file(go, name = ctx.label.name, ext = ".baseline.lcov")
+    _emit_baseline_coverage(go, sources = sources, out_lcov = out_lcov)
+    return {"baseline_coverage_files": [out_lcov]}
+
+def _emit_baseline_coverage(go, *, sources, out_lcov):
+    """Emits the action that writes every coverable line in sources at count zero.
+
+    Args:
+        go: the Go context.
+        sources: candidate source files. Non-Go files are ignored, as are Go
+            files excluded by build constraints.
+        out_lcov: the File to write the LCOV tracefile to.
+    """
+    sdk = go.sdk
+    go_srcs = [src for src in sources if src.extension == "go"]
+
+    args = go.builder_args(go)
+    args.add_all(go_srcs, before_each = "-src")
+    args.add("-o", out_lcov)
+
+    go.actions.run(
+        inputs = depset(go_srcs, transitive = [sdk.headers, sdk.tools]),
+        outputs = [out_lcov],
+        mnemonic = "GoBaselineCoverage",
+        executable = go.toolchain._builder,
+        arguments = ["baselinecoverage", args],
+        toolchain = GO_TOOLCHAIN_LABEL,
+    )

--- a/go/private/actions/baseline_coverage.bzl
+++ b/go/private/actions/baseline_coverage.bzl
@@ -46,14 +46,15 @@ def baseline_coverage_kwargs(go, ctx, sources):
         return {}
 
     out_lcov = go.declare_file(go, name = ctx.label.name, ext = ".baseline.lcov")
-    _emit_baseline_coverage(go, sources = sources, out_lcov = out_lcov)
+    _emit_baseline_coverage(go, ctx, sources = sources, out_lcov = out_lcov)
     return {"baseline_coverage_files": [out_lcov]}
 
-def _emit_baseline_coverage(go, *, sources, out_lcov):
+def _emit_baseline_coverage(go, ctx, *, sources, out_lcov):
     """Emits the action that writes every coverable line in sources at count zero.
 
     Args:
         go: the Go context.
+        ctx: the rule context.
         sources: candidate source files. Non-Go files are ignored, as are Go
             files excluded by build constraints.
         out_lcov: the File to write the LCOV tracefile to.
@@ -65,17 +66,29 @@ def _emit_baseline_coverage(go, *, sources, out_lcov):
     args.add_all(go_srcs, before_each = "-src")
     args.add("-o", out_lcov)
 
+    # The source paths this action writes to the tracefile have to be the same
+    # strings the compile action writes, or the baseline's zeros land in a
+    # separate record instead of being displaced by measured data. Path mapping
+    # rewrites the paths of generated sources, so it can only be enabled where
+    # compilepkg also enables it. See the matching condition there.
+    if getattr(ctx.attr, "cgo", False) or "local" in ctx.attr.tags:
+        env = go.env
+        execution_requirements = {}
+    else:
+        # The environment carries GOOS, GOARCH and CGO_ENABLED, which decide
+        # which sources the build constraints select. GOROOT is dropped and
+        # passed as an argument by builder_args instead, since path mapping
+        # cannot map environment variable values.
+        env = go.env_for_path_mapping
+        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT
+
     go.actions.run(
         inputs = depset(go_srcs, transitive = [sdk.headers, sdk.tools]),
         outputs = [out_lcov],
         mnemonic = "GoBaselineCoverage",
         executable = go.toolchain._builder,
         arguments = ["baselinecoverage", args],
-        # The environment carries GOOS, GOARCH and CGO_ENABLED, which decide
-        # which sources the build constraints select. GOROOT is dropped and
-        # passed as an argument by builder_args instead, since path mapping
-        # cannot map environment variable values.
-        env = go.env_for_path_mapping,
-        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT,
+        env = env,
+        execution_requirements = execution_requirements,
         toolchain = GO_TOOLCHAIN_LABEL,
     )

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -17,7 +17,7 @@ load(
     "//go/private:mode.bzl",
     "link_mode_arg",
 )
-load("//go/private/actions:utils.bzl", "quote_opts")
+load("//go/private/actions:utils.bzl", "path_mapping_action_settings", "quote_opts")
 
 def _archive(v):
     importpaths = [v.data.importpath]
@@ -165,13 +165,7 @@ def emit_compilepkg(
 
     # cgo and the linker action don't support path mapping yet
     # TODO: Remove the second condition after https://github.com/bazelbuild/bazel/pull/21921.
-    if cgo or "local" in go._ctx.attr.tags:
-        # cgo doesn't support path mapping yet
-        env = go.env
-        execution_requirements = {}
-    else:
-        env = go.env_for_path_mapping
-        execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT
+    env, execution_requirements = path_mapping_action_settings(go, cgo)
     cgo_go_srcs = None
     if cgo:
         if cgo_out_dir:

--- a/go/private/actions/utils.bzl
+++ b/go/private/actions/utils.bzl
@@ -2,6 +2,13 @@ load(
     "@bazel_skylib//lib:shell.bzl",
     "shell",
 )
+load("//go/private:common.bzl", "SUPPORTS_PATH_MAPPING_REQUIREMENT")
 
 def quote_opts(opts):
     return " ".join([shell.quote(opt) if " " in opt else opt for opt in opts])
+
+def path_mapping_action_settings(go, cgo = False):
+    """Returns the environment and execution requirements for a Go action."""
+    if cgo or "local" in go._ctx.attr.tags:
+        return go.env, {}
+    return go.env_for_path_mapping, SUPPORTS_PATH_MAPPING_REQUIREMENT

--- a/go/private/go_toolchain.bzl
+++ b/go/private/go_toolchain.bzl
@@ -51,6 +51,7 @@ def _go_toolchain_impl(ctx):
             # Internal fields -- may be read by emit functions.
             _builder = ctx.executable.builder,
             _pack = ctx.executable.pack,
+            _covdata = ctx.executable.covdata,
         ),
     ]
 
@@ -69,6 +70,12 @@ go_toolchain = rule(
             cfg = "exec",
             executable = True,
             doc = "Tool used to pack object files into archives",
+        ),
+        "covdata": attr.label(
+            cfg = "exec",
+            executable = True,
+            doc = """Tool used to decode coverage meta-data files. If absent,
+            no baseline coverage is emitted for packages without tests.""",
         ),
         "goos": attr.string(
             mandatory = True,
@@ -96,7 +103,7 @@ go_toolchain = rule(
     provides = [platform_common.ToolchainInfo],
 )
 
-def declare_go_toolchains(exec_goos, sdk, builder, pack):
+def declare_go_toolchains(exec_goos, sdk, builder, pack, covdata):
     """Declares go_toolchain targets for each platform."""
     for p in PLATFORMS:
         if p.cgo:
@@ -117,6 +124,7 @@ def declare_go_toolchains(exec_goos, sdk, builder, pack):
             sdk = sdk,
             builder = builder,
             pack = pack,
+            covdata = covdata,
             link_flags = link_flags,
             cgo_link_flags = cgo_link_flags,
             tags = ["manual"],

--- a/go/private/polyfill_bazel_features.bzl
+++ b/go/private/polyfill_bazel_features.bzl
@@ -9,6 +9,12 @@ _POLYFILL_BAZEL_FEATURES = """bazel_features = struct(
     # WORKSPACE users have no use for bazel mod tidy.
     bazel_mod_tidy = False,
   ),
+  rules = struct(
+    # coverage_common.instrumented_files_info gained baseline_coverage_files in
+    # Bazel 9, which is also the release that removed WORKSPACE support. Any
+    # Bazel reaching this polyfill therefore predates the parameter.
+    instrumented_files_info_has_baseline_coverage_files = False,
+  ),
 )
 """
 

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -49,6 +49,7 @@ bzl_library(
         "//go/private:mode",
         "//go/private:providers",
         "//go/private:rpath",
+        "//go/private/actions:baseline_coverage",
         "//go/private/rules:transition",
     ],
 )
@@ -81,6 +82,7 @@ bzl_library(
         "//go/private:common",
         "//go/private:context",
         "//go/private:providers",
+        "//go/private/actions:baseline_coverage",
     ],
 )
 

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -558,6 +558,9 @@ set GOTELEMETRY=off
 set GOENV=off
 {go} build -trimpath -ldflags \"-buildid='' {ldflags}\" -o {out_pack} cmd/pack
 if %ERRORLEVEL% EQU 0 (
+  {go} build -trimpath -ldflags \"-buildid='' {ldflags}\" -o {out_covdata} cmd/covdata
+)
+if %ERRORLEVEL% EQU 0 (
   {go} build -trimpath -ldflags \"-buildid='' {ldflags}\" -o {out} {srcs}
 )
 set GO_EXIT_CODE=%ERRORLEVEL%
@@ -569,6 +572,7 @@ exit /b %GO_EXIT_CODE%
             go = sdk.go.path.replace("/", "\\"),
             out = out.path,
             out_pack = ctx.outputs.out_pack.path,
+            out_covdata = ctx.outputs.out_covdata.path,
             srcs = " ".join([f.path for f in ctx.files.srcs]),
             ldflags = ctx.attr.ldflags,
         )
@@ -584,13 +588,14 @@ exit /b %GO_EXIT_CODE%
                 transitive = [sdk.headers, sdk.srcs, sdk.tools],
             ),
             toolchain = None,
-            outputs = [out, ctx.outputs.out_pack, gotmp],
+            outputs = [out, ctx.outputs.out_pack, ctx.outputs.out_covdata, gotmp],
             mnemonic = "GoToolchainBinaryBuild",
         )
     else:
         # Pass (potentially) generated files in via args to support path mapping.
         args = ctx.actions.args()
         args.add(ctx.outputs.out_pack)
+        args.add(ctx.outputs.out_covdata)
         args.add(out)
         args.add_all(ctx.files.srcs)
 
@@ -626,7 +631,7 @@ exit /b %GO_EXIT_CODE%
                 transitive = [sdk.headers, sdk.srcs, sdk.libs, sdk.tools],
             ),
             toolchain = None,
-            outputs = [out, ctx.outputs.out_pack],
+            outputs = [out, ctx.outputs.out_pack, ctx.outputs.out_covdata],
             execution_requirements = SUPPORTS_PATH_MAPPING_REQUIREMENT,
             mnemonic = "GoToolchainBinaryBuild",
         )
@@ -652,6 +657,7 @@ go_tool_binary = rule(
             doc = "Raw value to pass to go build via -ldflags without tokenization",
         ),
         "out_pack": attr.output(),
+        "out_covdata": attr.output(),
         "_binary_wrapper": attr.label(
             allow_single_file = True,
             default = "//go/private/rules:binary_wrapper.sh",
@@ -669,9 +675,9 @@ just have a main package and only depend on the standard library and don't
 require build constraints.
 
 It is currently only used to build the `builder` tool maintained as part of
-rules_go as well as the `pack` tool provided by the Go SDK in source form
-only as of Go 1.25. Combining both builds into a single action drastically
-reduces the overall build time due to Go's own caching mechanism.
+rules_go as well as the `pack` and `covdata` tools provided by the Go SDK in
+source form only as of Go 1.25. Combining these builds into a single action
+drastically reduces the overall build time due to Go's own caching mechanism.
 """,
     toolchains = [config_common.toolchain_type("@bazel_tools//tools/sh:toolchain_type", mandatory = False)],
 )

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -48,6 +48,10 @@ load(
     "GoSDK",
 )
 load(
+    "//go/private/actions:baseline_coverage.bzl",
+    "baseline_coverage_kwargs",
+)
+load(
     "//go/private/rules:transition.bzl",
     "go_transition",
     "non_go_transition",
@@ -248,6 +252,7 @@ def _go_binary_impl(ctx):
             source_attributes = ["srcs"],
             dependency_attributes = ["data", "deps", "embed", "embedsrcs"],
             extensions = ["go"],
+            **baseline_coverage_kwargs(go, ctx, ctx.files.srcs)
         ),
     )
 

--- a/go/private/rules/binary_wrapper.sh
+++ b/go/private/rules/binary_wrapper.sh
@@ -13,9 +13,11 @@ export HOME="${PWD}/_go_tool_binary-fake-home-${1//\\//_}"
 trap "${GO_BINARY} clean -cache" EXIT
 
 # We do not use -a here as the cache drastically reduces the time spent
-# on the second go build invocation (roughly 50% faster).
+# on the subsequent go build invocations (roughly 50% faster).
 
 "${GO_BINARY}" build -trimpath -ldflags="-buildid=\"\" ${LD_FLAGS}" -o "$1" cmd/pack
-shift
+
+"${GO_BINARY}" build -trimpath -ldflags="-buildid=\"\" ${LD_FLAGS}" -o "$2" cmd/covdata
+shift 2
 
 "${GO_BINARY}" build -trimpath -ldflags="-buildid=\"\" ${LD_FLAGS}" -o "$@"

--- a/go/private/rules/library.bzl
+++ b/go/private/rules/library.bzl
@@ -32,6 +32,10 @@ load(
     "GoInfo",
 )
 load(
+    "//go/private/actions:baseline_coverage.bzl",
+    "baseline_coverage_kwargs",
+)
+load(
     "//go/private/rules:transition.bzl",
     "non_go_transition",
 )
@@ -64,6 +68,7 @@ def _go_library_impl(ctx):
             source_attributes = ["srcs"],
             dependency_attributes = ["data", "deps", "embed", "embedsrcs"],
             extensions = ["go"],
+            **baseline_coverage_kwargs(go, ctx, ctx.files.srcs)
         ),
         OutputGroupInfo(
             cgo_exports = archive.cgo_exports,

--- a/go/private/sdk_build_defs.bzl
+++ b/go/private/sdk_build_defs.bzl
@@ -70,6 +70,7 @@ def define_sdk_repository_targets(
         # The .exe suffix is required on Windows and harmless on other platforms.
         # Output attributes are not configurable, so we use it everywhere.
         out_pack = "pack.exe",
+        out_covdata = "covdata.exe",
         sdk = ":go_sdk",
     )
 
@@ -83,6 +84,11 @@ def define_sdk_repository_targets(
         dep = ":pack.exe",
     )
 
+    non_go_reset_target(
+        name = "covdata_reset",
+        dep = ":covdata.exe",
+    )
+
     # TODO(jayconrod): Gazelle depends on this file directly. This dependency
     # should be broken, and this rule should be folded into go_sdk.
     package_list(
@@ -94,6 +100,7 @@ def define_sdk_repository_targets(
 
     declare_go_toolchains(
         builder = ":builder_reset",
+        covdata = ":covdata_reset",
         exec_goos = goos,
         pack = ":pack_reset",
         sdk = ":go_sdk",

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -29,6 +29,21 @@ go_test(
 )
 
 go_test(
+    name = "baseline_coverage_test",
+    size = "small",
+    srcs = [
+        "baseline_coverage.go",
+        "baseline_coverage_test.go",
+        "cover.go",
+        "edit.go",
+        "env.go",
+        "filter.go",
+        "flags.go",
+        "read.go",
+    ],
+)
+
+go_test(
     name = "cover_test",
     size = "small",
     srcs = [

--- a/go/tools/builders/BUILD.bazel
+++ b/go/tools/builders/BUILD.bazel
@@ -123,6 +123,7 @@ filegroup(
     srcs = [
         "ar.go",
         "asm.go",
+        "baseline_coverage.go",
         "builder.go",
         "buildinfo.go",
         "cc.go",

--- a/go/tools/builders/baseline_coverage.go
+++ b/go/tools/builders/baseline_coverage.go
@@ -104,14 +104,11 @@ func baselineLCOV(goenv *env, goSrcs []fileInfo) (string, error) {
 
 	var out strings.Builder
 	for i, src := range goSrcs {
-		// cgo sources are rewritten before the compiler sees them, so line
-		// numbers taken from the unprocessed source would not line up with
-		// what a real coverage run reports. Leave them to Bazel's stub rather
-		// than emit subtly wrong data.
-		if src.isCgo {
-			continue
-		}
-
+		// cgo sources are included. compilepkg instruments them before cgo
+		// rewrites them, so a measured run reports positions in the
+		// unprocessed source -- the same ones read back here. Cgo sources
+		// that are not compiled at all, because CGO_ENABLED is 0, have
+		// already been filtered out.
 		lines, err := coverableLines(goenv, workDir, i, src.filename)
 		if err != nil {
 			return "", err

--- a/go/tools/builders/baseline_coverage.go
+++ b/go/tools/builders/baseline_coverage.go
@@ -153,6 +153,22 @@ func coverableLines(goenv *env, workDir string, index int, srcName string) ([]in
 	if err != nil {
 		return nil, fmt.Errorf("reading coverage positions for %s: %w", srcName, err)
 	}
+	if len(blocks) == 0 {
+		// A file with no function bodies genuinely has no coverable lines, and
+		// must report LF:0. But zero blocks is also what a cover tool whose
+		// output this no longer understands would produce, and that failure
+		// would be invisible: every file would report LF:0, which is the very
+		// state this action exists to fix. Distinguish the two by asking the
+		// original source whether there was anything to instrument.
+		hasBody, err := hasFuncBody(srcName)
+		if err != nil {
+			return nil, err
+		}
+		if hasBody {
+			return nil, fmt.Errorf("no coverage blocks found for %s, but it declares a function body; "+
+				"the Go SDK's cover tool may have changed the format this parses", srcName)
+		}
+	}
 
 	seen := make(map[int]struct{})
 	for _, b := range blocks {
@@ -166,6 +182,24 @@ func coverableLines(goenv *env, workDir string, index int, srcName string) ([]in
 	}
 	sort.Ints(lines)
 	return lines, nil
+}
+
+// hasFuncBody reports whether the file declares at least one function with a
+// body, which is the minimum for cmd/cover to record a block. A body-less
+// declaration -- a forward declaration for an assembly implementation, say --
+// has nothing to instrument and does not count.
+func hasFuncBody(path string) (bool, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return false, err
+	}
+	for _, decl := range f.Decls {
+		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // coverBlock is one instrumented basic block's line span.
@@ -192,8 +226,10 @@ type coverBlock struct {
 // where Pos holds one triple per block: start line, end line, and the two
 // columns packed into a single word. Only the line numbers are of interest.
 //
-// A file with no functions is instrumented into a file with no such
-// declaration; that yields no blocks and is not an error.
+// The declaration is emitted even for a file with nothing to instrument, in
+// which case Pos is empty and this yields no blocks. Its absence therefore
+// means the output was not understood rather than that the file was empty.
+// Callers treat that as an error when the source had a function to instrument.
 func parseCoverPositions(path string) ([]coverBlock, error) {
 	fset := token.NewFileSet()
 	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)

--- a/go/tools/builders/baseline_coverage.go
+++ b/go/tools/builders/baseline_coverage.go
@@ -136,14 +136,14 @@ func coverableLines(goenv *env, workDir string, index int, srcName string) ([]in
 	instrumented := filepath.Join(workDir, fmt.Sprintf("baseline.%d.%s", index, filepath.Base(srcName)))
 
 	// The single-file form of cmd/cover is used deliberately over the -pkgcfg
-	// form. -pkgcfg can emit a coverage meta-data file directly (its
-	// EmitMetaFile field exists for "go test -cover" on a package with no test
-	// files, exactly this situation), but decoding that file requires the
-	// covdata tool, which the Go SDK does not ship prebuilt -- the go command
-	// compiles it on demand into the user's build cache. An action cannot rely
-	// on that. The single-file form needs only pkg/tool/<platform>/cover, which
-	// rules_go already depends on, and its position table carries the same
-	// blocks -pkgcfg would have recorded.
+	// form. -pkgcfg emits a coverage meta-data file that this action cannot
+	// read: Go 1.25 dropped the prebuilt covdata from the distribution, and
+	// go_tool_binary builds with "go build", which rejects the
+	// internal/coverage imports needed to decode one in process. Single-file
+	// mode needs only pkg/tool/<platform>/cover, already an input.
+	//
+	// The block positions are identical either way. Both forms record spans
+	// from one shared AST walk and differ only in where they store them.
 	goargs := goenv.goTool("cover", "-mode", baselineCoverMode, "-var", baselineCoverVar, "-o", instrumented, srcName)
 	if err := goenv.runCommand(goargs); err != nil {
 		return nil, fmt.Errorf("instrumenting %s: %w", srcName, err)

--- a/go/tools/builders/baseline_coverage.go
+++ b/go/tools/builders/baseline_coverage.go
@@ -1,0 +1,285 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// baselineCoverVar is the variable name given to the coverage struct in the
+// throwaway instrumented sources this action produces. It is never compiled;
+// only the position table inside it is read back.
+const baselineCoverVar = "GoBaselineCover"
+
+// baselineCoverMode is the mode cmd/cover is invoked with. Any mode yields the
+// same block positions -- the mode only decides how counts are recorded at run
+// time, and no baseline block is ever executed -- so the cheapest is used.
+const baselineCoverMode = "set"
+
+// baselineCoverage writes a "baseline" LCOV tracefile for a Go package: every
+// coverable line in the package, each with an execution count of zero.
+//
+// Bazel requests a baseline so that a package no test ever links still appears
+// in the combined coverage report. Absent one, Bazel substitutes a stub that
+// names the source file and nothing else, which its LcovPrinter renders as
+// "LF:0/LH:0". A consumer cannot tell that apart from a file with genuinely
+// nothing to cover, so wholly untested packages report 100% instead of 0%.
+// See https://github.com/bazelbuild/bazel/issues/5716.
+//
+// The line set comes from "go tool cover" rather than from an independent
+// source analysis, so it agrees exactly with what a real coverage run reports —
+// including multi-line statements, case clauses and closing braces, which a
+// statement-position approximation gets wrong.
+func baselineCoverage(args []string) error {
+	args, _, err := expandParamsFiles(args)
+	if err != nil {
+		return err
+	}
+
+	fs := flag.NewFlagSet("GoBaselineCoverage", flag.ExitOnError)
+	goenv := envFlags(fs)
+	var unfilteredSrcs multiFlag
+	var outPath string
+	fs.Var(&unfilteredSrcs, "src", "A source file to consider for coverage. May be repeated.")
+	fs.StringVar(&outPath, "o", "", "The LCOV tracefile to write.")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
+		return err
+	}
+	if outPath == "" {
+		return fmt.Errorf("-o is required")
+	}
+
+	// Apply the same build-constraint filtering the compile action applies, so
+	// a file excluded on this GOOS/GOARCH is never reported as uncovered.
+	srcs, err := filterAndSplitFiles(unfilteredSrcs)
+	if err != nil {
+		return err
+	}
+
+	lcov, err := baselineLCOV(goenv, srcs.goSrcs)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(outPath, []byte(lcov), writeFileMode)
+}
+
+// baselineLCOV renders the coverable lines of goSrcs as LCOV with every count
+// zero. Sources excluded by build constraints have already been filtered out
+// and so are absent, correctly: they are not compiled on this platform and
+// nothing about them is coverable here.
+func baselineLCOV(goenv *env, goSrcs []fileInfo) (string, error) {
+	if len(goSrcs) == 0 {
+		return "", nil
+	}
+
+	workDir, cleanup, err := goenv.workDir()
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	var out strings.Builder
+	for i, src := range goSrcs {
+		// cgo sources are rewritten before the compiler sees them, so line
+		// numbers taken from the unprocessed source would not line up with
+		// what a real coverage run reports. Leave them to Bazel's stub rather
+		// than emit subtly wrong data.
+		if src.isCgo {
+			continue
+		}
+
+		lines, err := coverableLines(goenv, workDir, i, src.filename)
+		if err != nil {
+			return "", err
+		}
+
+		// Bazel merges LCOV across languages and requires exec-root-relative
+		// source paths. The filenames handed to this action already are, and
+		// compilepkg's lcov cover_format uses the very same strings.
+		//
+		// A file with nothing to cover is still named, with LF:0. That matches
+		// the shape of the stub this replaces, but now the zero is a measured
+		// fact rather than the absence of a measurement.
+		fmt.Fprintf(&out, "SF:%s\n", filepath.ToSlash(src.filename))
+		for _, line := range lines {
+			fmt.Fprintf(&out, "DA:%d,0\n", line)
+		}
+		fmt.Fprintf(&out, "LH:0\nLF:%d\nend_of_record\n", len(lines))
+	}
+	return out.String(), nil
+}
+
+// coverableLines instruments one source file and reads back the set of lines
+// the instrumentation covers, sorted and deduplicated.
+func coverableLines(goenv *env, workDir string, index int, srcName string) ([]int, error) {
+	instrumented := filepath.Join(workDir, fmt.Sprintf("baseline.%d.%s", index, filepath.Base(srcName)))
+
+	// The single-file form of cmd/cover is used deliberately over the -pkgcfg
+	// form. -pkgcfg can emit a coverage meta-data file directly (its
+	// EmitMetaFile field exists for "go test -cover" on a package with no test
+	// files, exactly this situation), but decoding that file requires the
+	// covdata tool, which the Go SDK does not ship prebuilt -- the go command
+	// compiles it on demand into the user's build cache. An action cannot rely
+	// on that. The single-file form needs only pkg/tool/<platform>/cover, which
+	// rules_go already depends on, and its position table carries the same
+	// blocks -pkgcfg would have recorded.
+	goargs := goenv.goTool("cover", "-mode", baselineCoverMode, "-var", baselineCoverVar, "-o", instrumented, srcName)
+	if err := goenv.runCommand(goargs); err != nil {
+		return nil, fmt.Errorf("instrumenting %s: %w", srcName, err)
+	}
+
+	blocks, err := parseCoverPositions(instrumented)
+	if err != nil {
+		return nil, fmt.Errorf("reading coverage positions for %s: %w", srcName, err)
+	}
+
+	seen := make(map[int]struct{})
+	for _, b := range blocks {
+		for line := b.startLine; line <= b.endLine; line++ {
+			seen[line] = struct{}{}
+		}
+	}
+	lines := make([]int, 0, len(seen))
+	for line := range seen {
+		lines = append(lines, line)
+	}
+	sort.Ints(lines)
+	return lines, nil
+}
+
+// coverBlock is one instrumented basic block's line span.
+type coverBlock struct {
+	startLine int
+	endLine   int
+}
+
+// parseCoverPositions extracts the block spans from a file instrumented by
+// cmd/cover. The instrumented source ends with a declaration of the form
+//
+//	var GoBaselineCover = struct {
+//		Count   [8]uint32
+//		Pos     [3 * 8]uint32
+//		NumStmt [8]uint16
+//	}{
+//		Pos: [3 * 8]uint32{
+//			22, 24, 0x16001d, // [0]
+//			...
+//		},
+//		...
+//	}
+//
+// where Pos holds one triple per block: start line, end line, and the two
+// columns packed into a single word. Only the line numbers are of interest.
+//
+// A file with no functions is instrumented into a file with no such
+// declaration; that yields no blocks and is not an error.
+func parseCoverPositions(path string) ([]coverBlock, error) {
+	fset := token.NewFileSet()
+	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
+	if err != nil {
+		return nil, err
+	}
+
+	lit := findCoverPosLiteral(f)
+	if lit == nil {
+		return nil, nil
+	}
+
+	if len(lit.Elts)%3 != 0 {
+		return nil, fmt.Errorf("position table has %d entries, want a multiple of 3", len(lit.Elts))
+	}
+	blocks := make([]coverBlock, 0, len(lit.Elts)/3)
+	for i := 0; i < len(lit.Elts); i += 3 {
+		startLine, err := parseUintLit(lit.Elts[i])
+		if err != nil {
+			return nil, err
+		}
+		endLine, err := parseUintLit(lit.Elts[i+1])
+		if err != nil {
+			return nil, err
+		}
+		if startLine == 0 || endLine < startLine {
+			return nil, fmt.Errorf("nonsensical block span %d-%d", startLine, endLine)
+		}
+		blocks = append(blocks, coverBlock{startLine: startLine, endLine: endLine})
+	}
+	return blocks, nil
+}
+
+// findCoverPosLiteral locates the "Pos" element of the coverage variable's
+// initializer, or nil when the file carries no instrumentation.
+func findCoverPosLiteral(f *ast.File) *ast.CompositeLit {
+	for _, decl := range f.Decls {
+		genDecl, ok := decl.(*ast.GenDecl)
+		if !ok || genDecl.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range genDecl.Specs {
+			valueSpec, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for i, name := range valueSpec.Names {
+				if name.Name != baselineCoverVar || i >= len(valueSpec.Values) {
+					continue
+				}
+				outer, ok := valueSpec.Values[i].(*ast.CompositeLit)
+				if !ok {
+					continue
+				}
+				for _, elt := range outer.Elts {
+					kv, ok := elt.(*ast.KeyValueExpr)
+					if !ok {
+						continue
+					}
+					key, ok := kv.Key.(*ast.Ident)
+					if !ok || key.Name != "Pos" {
+						continue
+					}
+					if inner, ok := kv.Value.(*ast.CompositeLit); ok {
+						return inner
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// parseUintLit reads a non-negative integer literal, which cmd/cover emits in
+// either decimal or hexadecimal.
+func parseUintLit(expr ast.Expr) (int, error) {
+	lit, ok := expr.(*ast.BasicLit)
+	if !ok || lit.Kind != token.INT {
+		return 0, fmt.Errorf("expected an integer literal, got %T", expr)
+	}
+	v, err := strconv.ParseUint(lit.Value, 0, 32)
+	if err != nil {
+		return 0, err
+	}
+	return int(v), nil
+}

--- a/go/tools/builders/baseline_coverage.go
+++ b/go/tools/builders/baseline_coverage.go
@@ -15,12 +15,14 @@
 package main
 
 import (
+	"bufio"
 	"crypto/md5"
 	"encoding/json"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -232,6 +234,16 @@ func coverableLines(goenv *env, covdataPath, importPath, workDir string, goSrcs 
 	return parseCoverProfile(string(profile))
 }
 
+// coverLinePattern matches one block line of a coverage profile. It is copied
+// verbatim from bzltestutil's converter, which parses the same text format for
+// measured coverage, so that both readers accept exactly the same input. The
+// pattern cannot be shared: builder is a go_tool_binary restricted to the
+// standard library, and bzltestutil imports coverdata.
+//
+// The greedy path group is what allows a source path to contain a space, which
+// splitting on whitespace would break.
+var coverLinePattern = regexp.MustCompile(`^(?P<path>.+):(?P<startLine>\d+)\.(?P<startColumn>\d+),(?P<endLine>\d+)\.(?P<endColumn>\d+) (?P<numStmt>\d+) (?P<count>\d+)$`)
+
 // parseCoverProfile extracts the per-file line sets from a coverage profile in
 // the text format emitted by "covdata textfmt": a "mode:" header followed by
 // one block per line,
@@ -242,22 +254,34 @@ func coverableLines(goenv *env, covdataPath, importPath, workDir string, goSrcs 
 // profile is rendered as LCOV after a coverage run.
 func parseCoverProfile(profile string) (map[string][]int, error) {
 	seen := make(map[string]map[int]bool)
-	for _, line := range strings.Split(profile, "\n") {
-		if line == "" || strings.HasPrefix(line, "mode:") {
-			continue
-		}
-		fields := strings.Fields(line)
-		if len(fields) != 3 {
+	// Read by lines the way bzltestutil does, so that a trailing carriage
+	// return is stripped rather than left to defeat the pattern's anchor.
+	scanner := bufio.NewScanner(strings.NewReader(profile))
+	for scanner.Scan() {
+		line := scanner.Text()
+		m := coverLinePattern.FindStringSubmatch(line)
+		if m == nil {
+			// Matching before this check, as bzltestutil does, so that a
+			// source path beginning with "mode:" is read as the record it is
+			// rather than mistaken for the header.
+			if line == "" || strings.HasPrefix(line, "mode: ") {
+				continue
+			}
 			return nil, fmt.Errorf("malformed line in coverage profile: %q", line)
 		}
-		colon := strings.LastIndexByte(fields[0], ':')
-		if colon <= 0 {
-			return nil, fmt.Errorf("malformed line in coverage profile: %q", line)
-		}
-		name := filepath.ToSlash(fields[0][:colon])
-		startLine, endLine, err := parseBlockSpan(fields[0][colon+1:])
+		// The paths are compared against the source names this action was
+		// given, which are slash-separated.
+		name := filepath.ToSlash(m[1])
+		startLine, err := strconv.Atoi(m[2])
 		if err != nil {
-			return nil, fmt.Errorf("malformed block span in coverage profile line %q: %v", line, err)
+			return nil, fmt.Errorf("malformed start line in coverage profile line %q: %v", line, err)
+		}
+		endLine, err := strconv.Atoi(m[4])
+		if err != nil {
+			return nil, fmt.Errorf("malformed end line in coverage profile line %q: %v", line, err)
+		}
+		if startLine <= 0 || endLine < startLine {
+			return nil, fmt.Errorf("nonsensical block span %d-%d in coverage profile line %q", startLine, endLine, line)
 		}
 		if seen[name] == nil {
 			seen[name] = make(map[int]bool)
@@ -265,6 +289,9 @@ func parseCoverProfile(profile string) (map[string][]int, error) {
 		for l := startLine; l <= endLine; l++ {
 			seen[name][l] = true
 		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("reading coverage profile: %w", err)
 	}
 
 	linesByFile := make(map[string][]int, len(seen))
@@ -277,32 +304,4 @@ func parseCoverProfile(profile string) (map[string][]int, error) {
 		linesByFile[name] = lines
 	}
 	return linesByFile, nil
-}
-
-// parseBlockSpan reads the lines of a "startLine.startCol,endLine.endCol"
-// block position.
-func parseBlockSpan(span string) (startLine, endLine int, err error) {
-	start, end, ok := strings.Cut(span, ",")
-	if !ok {
-		return 0, 0, fmt.Errorf("expected two positions separated by a comma")
-	}
-	if startLine, err = parsePositionLine(start); err != nil {
-		return 0, 0, err
-	}
-	if endLine, err = parsePositionLine(end); err != nil {
-		return 0, 0, err
-	}
-	if startLine <= 0 || endLine < startLine {
-		return 0, 0, fmt.Errorf("nonsensical block span %d-%d", startLine, endLine)
-	}
-	return startLine, endLine, nil
-}
-
-// parsePositionLine reads the line number of a "line.column" position.
-func parsePositionLine(pos string) (int, error) {
-	lineStr, _, ok := strings.Cut(pos, ".")
-	if !ok {
-		return 0, fmt.Errorf("expected a line.column position, got %q", pos)
-	}
-	return strconv.Atoi(lineStr)
 }

--- a/go/tools/builders/baseline_coverage.go
+++ b/go/tools/builders/baseline_coverage.go
@@ -15,11 +15,10 @@
 package main
 
 import (
+	"crypto/md5"
+	"encoding/json"
 	"flag"
 	"fmt"
-	"go/ast"
-	"go/parser"
-	"go/token"
 	"os"
 	"path/filepath"
 	"sort"
@@ -27,9 +26,9 @@ import (
 	"strings"
 )
 
-// baselineCoverVar is the variable name given to the coverage struct in the
-// throwaway instrumented sources this action produces. It is never compiled;
-// only the position table inside it is read back.
+// baselineCoverVar is the prefix cmd/cover uses for the counter variables in
+// the throwaway instrumented sources this action produces. They are never
+// compiled; only the coverage meta-data file is read back.
 const baselineCoverVar = "GoBaselineCover"
 
 // baselineCoverMode is the mode cmd/cover is invoked with. Any mode yields the
@@ -60,9 +59,11 @@ func baselineCoverage(args []string) error {
 	fs := flag.NewFlagSet("GoBaselineCoverage", flag.ExitOnError)
 	goenv := envFlags(fs)
 	var unfilteredSrcs multiFlag
-	var outPath string
+	var outPath, covdataPath, importPath string
 	fs.Var(&unfilteredSrcs, "src", "A source file to consider for coverage. May be repeated.")
 	fs.StringVar(&outPath, "o", "", "The LCOV tracefile to write.")
+	fs.StringVar(&covdataPath, "covdata", "", "The path to the covdata tool.")
+	fs.StringVar(&importPath, "importpath", "", "The import path of the package. May be empty.")
 	if err := fs.Parse(args); err != nil {
 		return err
 	}
@@ -72,6 +73,9 @@ func baselineCoverage(args []string) error {
 	if outPath == "" {
 		return fmt.Errorf("-o is required")
 	}
+	if covdataPath == "" {
+		return fmt.Errorf("-covdata is required")
+	}
 
 	// Apply the same build-constraint filtering the compile action applies, so
 	// a file excluded on this GOOS/GOARCH is never reported as uncovered.
@@ -80,7 +84,7 @@ func baselineCoverage(args []string) error {
 		return err
 	}
 
-	lcov, err := baselineLCOV(goenv, srcs.goSrcs)
+	lcov, err := baselineLCOV(goenv, covdataPath, importPath, srcs.goSrcs)
 	if err != nil {
 		return err
 	}
@@ -91,7 +95,7 @@ func baselineCoverage(args []string) error {
 // zero. Sources excluded by build constraints have already been filtered out
 // and so are absent, correctly: they are not compiled on this platform and
 // nothing about them is coverable here.
-func baselineLCOV(goenv *env, goSrcs []fileInfo) (string, error) {
+func baselineLCOV(goenv *env, covdataPath, importPath string, goSrcs []fileInfo) (string, error) {
 	if len(goSrcs) == 0 {
 		return "", nil
 	}
@@ -102,18 +106,13 @@ func baselineLCOV(goenv *env, goSrcs []fileInfo) (string, error) {
 	}
 	defer cleanup()
 
-	var out strings.Builder
-	for i, src := range goSrcs {
-		// cgo sources are included. compilepkg instruments them before cgo
-		// rewrites them, so a measured run reports positions in the
-		// unprocessed source -- the same ones read back here. Cgo sources
-		// that are not compiled at all, because CGO_ENABLED is 0, have
-		// already been filtered out.
-		lines, err := coverableLines(goenv, workDir, i, src.filename)
-		if err != nil {
-			return "", err
-		}
+	linesByFile, err := coverableLines(goenv, covdataPath, importPath, workDir, goSrcs)
+	if err != nil {
+		return "", err
+	}
 
+	var out strings.Builder
+	for _, src := range goSrcs {
 		// Bazel merges LCOV across languages and requires exec-root-relative
 		// source paths. The filenames handed to this action already are, and
 		// compilepkg's lcov cover_format uses the very same strings.
@@ -121,198 +120,189 @@ func baselineLCOV(goenv *env, goSrcs []fileInfo) (string, error) {
 		// A file with nothing to cover is still named, with LF:0. That matches
 		// the shape of the stub this replaces, but now the zero is a measured
 		// fact rather than the absence of a measurement.
-		fmt.Fprintf(&out, "SF:%s\n", filepath.ToSlash(src.filename))
+		name := filepath.ToSlash(src.filename)
+		lines := linesByFile[name]
+		delete(linesByFile, name)
+		fmt.Fprintf(&out, "SF:%s\n", name)
 		for _, line := range lines {
 			fmt.Fprintf(&out, "DA:%d,0\n", line)
 		}
 		fmt.Fprintf(&out, "LH:0\nLF:%d\nend_of_record\n", len(lines))
 	}
+	for name := range linesByFile {
+		return "", fmt.Errorf("cover reported coverable lines in %s, which is not among the package's sources", name)
+	}
 	return out.String(), nil
 }
 
-// coverableLines instruments one source file and reads back the set of lines
-// the instrumentation covers, sorted and deduplicated.
-func coverableLines(goenv *env, workDir string, index int, srcName string) ([]int, error) {
-	instrumented := filepath.Join(workDir, fmt.Sprintf("baseline.%d.%s", index, filepath.Base(srcName)))
-
-	// The single-file form of cmd/cover is used deliberately over the -pkgcfg
-	// form. -pkgcfg emits a coverage meta-data file that this action cannot
-	// read: Go 1.25 dropped the prebuilt covdata from the distribution, and
-	// go_tool_binary builds with "go build", which rejects the
-	// internal/coverage imports needed to decode one in process. Single-file
-	// mode needs only pkg/tool/<platform>/cover, already an input.
-	//
-	// The block positions are identical either way. Both forms record spans
-	// from one shared AST walk and differ only in where they store them.
-	goargs := goenv.goTool("cover", "-mode", baselineCoverMode, "-var", baselineCoverVar, "-o", instrumented, srcName)
-	if err := goenv.runCommand(goargs); err != nil {
-		return nil, fmt.Errorf("instrumenting %s: %w", srcName, err)
-	}
-
-	blocks, err := parseCoverPositions(instrumented)
-	if err != nil {
-		return nil, fmt.Errorf("reading coverage positions for %s: %w", srcName, err)
-	}
-	if len(blocks) == 0 {
-		// A file with no function bodies genuinely has no coverable lines, and
-		// must report LF:0. But zero blocks is also what a cover tool whose
-		// output this no longer understands would produce, and that failure
-		// would be invisible: every file would report LF:0, which is the very
-		// state this action exists to fix. Distinguish the two by asking the
-		// original source whether there was anything to instrument.
-		hasBody, err := hasFuncBody(srcName)
-		if err != nil {
-			return nil, err
-		}
-		if hasBody {
-			return nil, fmt.Errorf("no coverage blocks found for %s, but it declares a function body; "+
-				"the Go SDK's cover tool may have changed the format this parses", srcName)
-		}
-	}
-
-	seen := make(map[int]struct{})
-	for _, b := range blocks {
-		for line := b.startLine; line <= b.endLine; line++ {
-			seen[line] = struct{}{}
-		}
-	}
-	lines := make([]int, 0, len(seen))
-	for line := range seen {
-		lines = append(lines, line)
-	}
-	sort.Ints(lines)
-	return lines, nil
-}
-
-// hasFuncBody reports whether the file declares at least one function with a
-// body, which is the minimum for cmd/cover to record a block. A body-less
-// declaration -- a forward declaration for an assembly implementation, say --
-// has nothing to instrument and does not count.
-func hasFuncBody(path string) (bool, error) {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
-	if err != nil {
-		return false, err
-	}
-	for _, decl := range f.Decls {
-		if fn, ok := decl.(*ast.FuncDecl); ok && fn.Body != nil {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
-// coverBlock is one instrumented basic block's line span.
-type coverBlock struct {
-	startLine int
-	endLine   int
-}
-
-// parseCoverPositions extracts the block spans from a file instrumented by
-// cmd/cover. The instrumented source ends with a declaration of the form
+// coverableLines instruments the package once with cmd/cover's -pkgcfg mode,
+// which emits a coverage meta-data file, and decodes that file with the
+// covdata tool into the set of coverable lines per source file, sorted and
+// deduplicated.
 //
-//	var GoBaselineCover = struct {
-//		Count   [8]uint32
-//		Pos     [3 * 8]uint32
-//		NumStmt [8]uint16
-//	}{
-//		Pos: [3 * 8]uint32{
-//			22, 24, 0x16001d, // [0]
-//			...
-//		},
-//		...
-//	}
-//
-// where Pos holds one triple per block: start line, end line, and the two
-// columns packed into a single word. Only the line numbers are of interest.
-//
-// The declaration is emitted even for a file with nothing to instrument, in
-// which case Pos is empty and this yields no blocks. Its absence therefore
-// means the output was not understood rather than that the file was empty.
-// Callers treat that as an error when the source had a function to instrument.
-func parseCoverPositions(path string) ([]coverBlock, error) {
-	fset := token.NewFileSet()
-	f, err := parser.ParseFile(fset, path, nil, parser.SkipObjectResolution)
-	if err != nil {
+// cgo sources are included. compilepkg instruments them before cgo rewrites
+// them, so a measured run reports positions in the unprocessed source -- the
+// same ones read back here. Cgo sources that are not compiled at all, because
+// CGO_ENABLED is 0, have already been filtered out.
+func coverableLines(goenv *env, covdataPath, importPath, workDir string, goSrcs []fileInfo) (map[string][]int, error) {
+	// cmd/cover refuses an empty PkgPath, but with Local set the file names it
+	// records never include it, so a placeholder serves for the packages that
+	// have no import path, such as most binaries.
+	if importPath == "" {
+		importPath = "baseline-coverage"
+	}
+
+	metaDir := filepath.Join(workDir, "covmeta")
+	if err := os.Mkdir(metaDir, 0o777); err != nil {
 		return nil, err
 	}
 
-	lit := findCoverPosLiteral(f)
-	if lit == nil {
+	// The file name must match the covmeta.<tag> shape covdata looks for. The
+	// tag itself only distinguishes multiple meta files in one directory, of
+	// which there is one.
+	metaFile := filepath.Join(metaDir, fmt.Sprintf("covmeta.%x", md5.Sum([]byte(importPath))))
+
+	// EmitMetaFile exists for "go test -cover" on a package with no test
+	// files, which needs the block positions of a package that is never
+	// linked into a test binary -- exactly this action's situation. Local
+	// makes cmd/cover record each source file under the name it was given on
+	// the command line, which is already exec-root-relative, rather than under
+	// <importpath>/<basename>.
+	cfg := coverPkgConfig{
+		OutConfig:    filepath.Join(workDir, "outcfg.txt"),
+		PkgPath:      importPath,
+		PkgName:      goSrcs[0].pkg,
+		Granularity:  "perblock",
+		Local:        true,
+		EmitMetaFile: metaFile,
+	}
+	cfgData, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, err
+	}
+	pkgcfgPath := filepath.Join(workDir, "pkgcfg.json")
+	if err := os.WriteFile(pkgcfgPath, cfgData, writeFileMode); err != nil {
+		return nil, err
+	}
+
+	// cmd/cover insists on writing instrumented output: a covervars.go
+	// followed by one file per input. All of it is thrown away with the work
+	// directory; only the meta-data file is of interest.
+	var outList strings.Builder
+	fmt.Fprintf(&outList, "%s\n", filepath.Join(workDir, "covervars.go"))
+	for i := range goSrcs {
+		fmt.Fprintf(&outList, "%s\n", filepath.Join(workDir, fmt.Sprintf("baseline.%d.go", i)))
+	}
+	outListPath := filepath.Join(workDir, "outfilelist.txt")
+	if err := os.WriteFile(outListPath, []byte(outList.String()), writeFileMode); err != nil {
+		return nil, err
+	}
+
+	goargs := goenv.goTool("cover", "-pkgcfg", pkgcfgPath, "-var", baselineCoverVar, "-mode", baselineCoverMode, "-outfilelist", outListPath)
+	for _, src := range goSrcs {
+		goargs = append(goargs, src.filename)
+	}
+	if err := goenv.runCommand(goargs); err != nil {
+		return nil, fmt.Errorf("instrumenting package: %w", err)
+	}
+
+	// cmd/cover always creates the meta-data file, but leaves it empty for a
+	// package with no function bodies, which genuinely has no coverable lines.
+	// covdata cannot decode an empty file, and has nothing to say about one.
+	// An absent file means cmd/cover no longer honors EmitMetaFile, and that
+	// failure must be loud: quietly reporting LF:0 everywhere is the very
+	// state this action exists to fix.
+	info, err := os.Stat(metaFile)
+	if err != nil {
+		return nil, fmt.Errorf("the cover tool did not emit a coverage meta-data file for %s: %w", importPath, err)
+	}
+	if info.Size() == 0 {
 		return nil, nil
 	}
 
-	if len(lit.Elts)%3 != 0 {
-		return nil, fmt.Errorf("position table has %d entries, want a multiple of 3", len(lit.Elts))
+	profilePath := filepath.Join(workDir, "baseline.cov")
+	covdataArgs := []string{covdataPath, "textfmt", "-i=" + metaDir, "-o=" + profilePath}
+	if err := goenv.runCommand(covdataArgs); err != nil {
+		return nil, fmt.Errorf("decoding coverage meta-data for %s: %w", importPath, err)
 	}
-	blocks := make([]coverBlock, 0, len(lit.Elts)/3)
-	for i := 0; i < len(lit.Elts); i += 3 {
-		startLine, err := parseUintLit(lit.Elts[i])
-		if err != nil {
-			return nil, err
-		}
-		endLine, err := parseUintLit(lit.Elts[i+1])
-		if err != nil {
-			return nil, err
-		}
-		if startLine == 0 || endLine < startLine {
-			return nil, fmt.Errorf("nonsensical block span %d-%d", startLine, endLine)
-		}
-		blocks = append(blocks, coverBlock{startLine: startLine, endLine: endLine})
+	profile, err := os.ReadFile(profilePath)
+	if err != nil {
+		return nil, err
 	}
-	return blocks, nil
+	return parseCoverProfile(string(profile))
 }
 
-// findCoverPosLiteral locates the "Pos" element of the coverage variable's
-// initializer, or nil when the file carries no instrumentation.
-func findCoverPosLiteral(f *ast.File) *ast.CompositeLit {
-	for _, decl := range f.Decls {
-		genDecl, ok := decl.(*ast.GenDecl)
-		if !ok || genDecl.Tok != token.VAR {
+// parseCoverProfile extracts the per-file line sets from a coverage profile in
+// the text format emitted by "covdata textfmt": a "mode:" header followed by
+// one block per line,
+//
+//	name.go:startLine.startCol,endLine.endCol numStmt count
+//
+// Every line a block spans counts as coverable, matching how a measured
+// profile is rendered as LCOV after a coverage run.
+func parseCoverProfile(profile string) (map[string][]int, error) {
+	seen := make(map[string]map[int]bool)
+	for _, line := range strings.Split(profile, "\n") {
+		if line == "" || strings.HasPrefix(line, "mode:") {
 			continue
 		}
-		for _, spec := range genDecl.Specs {
-			valueSpec, ok := spec.(*ast.ValueSpec)
-			if !ok {
-				continue
-			}
-			for i, name := range valueSpec.Names {
-				if name.Name != baselineCoverVar || i >= len(valueSpec.Values) {
-					continue
-				}
-				outer, ok := valueSpec.Values[i].(*ast.CompositeLit)
-				if !ok {
-					continue
-				}
-				for _, elt := range outer.Elts {
-					kv, ok := elt.(*ast.KeyValueExpr)
-					if !ok {
-						continue
-					}
-					key, ok := kv.Key.(*ast.Ident)
-					if !ok || key.Name != "Pos" {
-						continue
-					}
-					if inner, ok := kv.Value.(*ast.CompositeLit); ok {
-						return inner
-					}
-				}
-			}
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("malformed line in coverage profile: %q", line)
+		}
+		colon := strings.LastIndexByte(fields[0], ':')
+		if colon <= 0 {
+			return nil, fmt.Errorf("malformed line in coverage profile: %q", line)
+		}
+		name := filepath.ToSlash(fields[0][:colon])
+		startLine, endLine, err := parseBlockSpan(fields[0][colon+1:])
+		if err != nil {
+			return nil, fmt.Errorf("malformed block span in coverage profile line %q: %v", line, err)
+		}
+		if seen[name] == nil {
+			seen[name] = make(map[int]bool)
+		}
+		for l := startLine; l <= endLine; l++ {
+			seen[name][l] = true
 		}
 	}
-	return nil
+
+	linesByFile := make(map[string][]int, len(seen))
+	for name, set := range seen {
+		lines := make([]int, 0, len(set))
+		for l := range set {
+			lines = append(lines, l)
+		}
+		sort.Ints(lines)
+		linesByFile[name] = lines
+	}
+	return linesByFile, nil
 }
 
-// parseUintLit reads a non-negative integer literal, which cmd/cover emits in
-// either decimal or hexadecimal.
-func parseUintLit(expr ast.Expr) (int, error) {
-	lit, ok := expr.(*ast.BasicLit)
-	if !ok || lit.Kind != token.INT {
-		return 0, fmt.Errorf("expected an integer literal, got %T", expr)
+// parseBlockSpan reads the lines of a "startLine.startCol,endLine.endCol"
+// block position.
+func parseBlockSpan(span string) (startLine, endLine int, err error) {
+	start, end, ok := strings.Cut(span, ",")
+	if !ok {
+		return 0, 0, fmt.Errorf("expected two positions separated by a comma")
 	}
-	v, err := strconv.ParseUint(lit.Value, 0, 32)
-	if err != nil {
-		return 0, err
+	if startLine, err = parsePositionLine(start); err != nil {
+		return 0, 0, err
 	}
-	return int(v), nil
+	if endLine, err = parsePositionLine(end); err != nil {
+		return 0, 0, err
+	}
+	if startLine <= 0 || endLine < startLine {
+		return 0, 0, fmt.Errorf("nonsensical block span %d-%d", startLine, endLine)
+	}
+	return startLine, endLine, nil
+}
+
+// parsePositionLine reads the line number of a "line.column" position.
+func parsePositionLine(pos string) (int, error) {
+	lineStr, _, ok := strings.Cut(pos, ".")
+	if !ok {
+		return 0, fmt.Errorf("expected a line.column position, got %q", pos)
+	}
+	return strconv.Atoi(lineStr)
 }

--- a/go/tools/builders/baseline_coverage_test.go
+++ b/go/tools/builders/baseline_coverage_test.go
@@ -1,0 +1,121 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseCoverProfile(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		profile string
+		want    map[string][]int
+	}{
+		{
+			desc: "a block covers every line it spans",
+			profile: "mode: set\n" +
+				"pkg/sample.go:3.24,4.11 1 0\n" +
+				"pkg/sample.go:4.11,6.3 1 0\n",
+			want: map[string][]int{"pkg/sample.go": {3, 4, 5, 6}},
+		},
+		{
+			desc: "overlapping blocks report each line once",
+			profile: "mode: set\n" +
+				"a.go:1.1,3.2 1 0\n" +
+				"a.go:2.1,4.2 1 0\n",
+			want: map[string][]int{"a.go": {1, 2, 3, 4}},
+		},
+		{
+			desc: "blocks are grouped by source file",
+			profile: "mode: set\n" +
+				"a.go:1.1,1.2 1 0\n" +
+				"b.go:7.1,7.2 1 0\n",
+			want: map[string][]int{"a.go": {1}, "b.go": {7}},
+		},
+		{
+			// covdata writes the path unescaped, so splitting the line on
+			// whitespace would take "sp" for the whole record.
+			desc:    "a path containing a space is read whole",
+			profile: "mode: set\nsp ace/sample.go:5.26,6.11 1 0\n",
+			want:    map[string][]int{"sp ace/sample.go": {5, 6}},
+		},
+		{
+			desc:    "a path containing a colon is split at the last one",
+			profile: "mode: set\nweird:dir/sample.go:2.1,2.9 1 0\n",
+			want:    map[string][]int{"weird:dir/sample.go": {2}},
+		},
+		{
+			// The header check runs only once the record pattern has failed,
+			// so a path that looks like the header is not mistaken for it.
+			desc:    "a path beginning with mode: is a record",
+			profile: "mode: set\nmode:x.go:2.1,2.9 1 0\n",
+			want:    map[string][]int{"mode:x.go": {2}},
+		},
+		{
+			// covdata leaves a trailing carriage return on Windows.
+			desc:    "a carriage return does not defeat the line anchor",
+			profile: "mode: set\r\na.go:1.1,2.2 1 0\r\n",
+			want:    map[string][]int{"a.go": {1, 2}},
+		},
+		{
+			desc:    "an empty profile has no records",
+			profile: "",
+			want:    map[string][]int{},
+		},
+		{
+			desc:    "a header alone has no records",
+			profile: "mode: set\n",
+			want:    map[string][]int{},
+		},
+		{
+			desc:    "blank lines are skipped",
+			profile: "mode: set\n\na.go:1.1,1.2 1 0\n\n",
+			want:    map[string][]int{"a.go": {1}},
+		},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			got, err := parseCoverProfile(test.profile)
+			if err != nil {
+				t.Fatalf("parseCoverProfile returned an unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				t.Errorf("parseCoverProfile = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestParseCoverProfileRejectsMalformedInput(t *testing.T) {
+	for _, test := range []struct {
+		desc    string
+		profile string
+	}{
+		{"a line with no block position", "mode: set\nnot a profile line\n"},
+		{"a record missing its counts", "mode: set\na.go:1.1,2.2\n"},
+		{"a record missing a column", "mode: set\na.go:1,2.2 1 0\n"},
+		{"a non-numeric line number", "mode: set\na.go:x.1,2.2 1 0\n"},
+		{"an empty path", "mode: set\n:1.1,2.2 1 0\n"},
+		{"a block ending before it starts", "mode: set\na.go:5.1,2.2 1 0\n"},
+		{"a block starting at line zero", "mode: set\na.go:0.1,2.2 1 0\n"},
+	} {
+		t.Run(test.desc, func(t *testing.T) {
+			if _, err := parseCoverProfile(test.profile); err == nil {
+				t.Errorf("parseCoverProfile accepted %q, want an error", test.profile)
+			}
+		})
+	}
+}

--- a/go/tools/builders/builder.go
+++ b/go/tools/builders/builder.go
@@ -47,6 +47,8 @@ func main() {
 
 	var action func(args []string) error
 	switch verb {
+	case "baselinecoverage":
+		action = baselineCoverage
 	case "compilepkg":
 		action = compilePkg
 	case "nogo":

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@io_bazel_rules_go//go/tools/bazel_testing:def.bzl", "go_bazel_test")
+load("@io_bazel_rules_go_bazel_features//:features.bzl", "bazel_features")
 
 go_bazel_test(
     name = "coverage_test",
@@ -26,6 +27,17 @@ go_bazel_test(
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],
     }),
+)
+
+go_bazel_test(
+    name = "baseline_coverage_test",
+    srcs = ["baseline_coverage_test.go"],
+    # Baseline coverage requires Bazel 9's baseline_coverage_files parameter;
+    # on older Bazel the rules fall back to Bazel's empty stub.
+    target_compatible_with = select({
+        "@platforms//os:windows": ["@platforms//:incompatible"],
+        "//conditions:default": [],
+    }) if bazel_features.rules.instrumented_files_info_has_baseline_coverage_files else ["@platforms//:incompatible"],
 )
 
 go_bazel_test(

--- a/tests/core/coverage/BUILD.bazel
+++ b/tests/core/coverage/BUILD.bazel
@@ -32,8 +32,9 @@ go_bazel_test(
 go_bazel_test(
     name = "baseline_coverage_test",
     srcs = ["baseline_coverage_test.go"],
-    # Baseline coverage requires Bazel 9's baseline_coverage_files parameter;
-    # on older Bazel the rules fall back to Bazel's empty stub.
+    # Baseline coverage requires Bazel 9's baseline_coverage_files parameter.
+    # On Bazel 8 the rules fall back to Bazel's empty stub, so there is nothing
+    # for this to assert.
     target_compatible_with = select({
         "@platforms//os:windows": ["@platforms//:incompatible"],
         "//conditions:default": [],

--- a/tests/core/coverage/baseline_coverage_test.go
+++ b/tests/core/coverage/baseline_coverage_test.go
@@ -145,12 +145,6 @@ func main() {
 	fmt.Println("nobody tests me")
 }
 `,
-		// Baseline coverage needs Bazel 9, which dropped WORKSPACE support, so
-		// this test's generated workspace must use bzlmod. A non-empty suffix is
-		// what opts it in; no extra dependencies are required.
-		ModuleFileSuffix: `
-# Intentionally empty.
-`,
 	})
 }
 

--- a/tests/core/coverage/baseline_coverage_test.go
+++ b/tests/core/coverage/baseline_coverage_test.go
@@ -1,0 +1,233 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package baseline_coverage_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- src/BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+# Linked by a test, so its coverage is measured for real. Present here to prove
+# the baseline never displaces measured data.
+go_library(
+    name = "tested",
+    srcs = ["tested.go"],
+    importpath = "example.com/tested",
+)
+
+go_test(
+    name = "tested_test",
+    srcs = ["tested_test.go"],
+    embed = [":tested"],
+)
+
+# No test anywhere links this. Before baseline coverage it appeared in the
+# combined report as an empty record, which reads as 100%.
+go_library(
+    name = "untested",
+    srcs = ["untested.go"],
+    importpath = "example.com/untested",
+)
+
+# Declarations only: there is genuinely nothing to cover, which must stay
+# distinguishable from the case above.
+go_library(
+    name = "declarations",
+    srcs = ["declarations.go"],
+    importpath = "example.com/declarations",
+)
+
+# Excluded by a build constraint that never matches, so it must not be reported
+# as uncovered.
+go_library(
+    name = "constrained",
+    srcs = ["constrained.go"],
+    importpath = "example.com/constrained",
+)
+
+go_binary(
+    name = "untested_bin",
+    srcs = ["untested_bin.go"],
+)
+-- src/tested.go --
+package tested
+
+func Greet(informal bool) string {
+	if informal {
+		return "hi"
+	}
+	return "hello"
+}
+-- src/tested_test.go --
+package tested
+
+import "testing"
+
+func TestGreet(t *testing.T) {
+	if Greet(false) != "hello" {
+		t.Error("expected hello")
+	}
+}
+-- src/untested.go --
+package untested
+
+func Sum(xs []int) int {
+	total := 0
+	for _, x := range xs {
+		total += x
+	}
+	return total
+}
+-- src/declarations.go --
+package declarations
+
+type Config struct {
+	Name string
+}
+
+const Answer = 42
+-- src/constrained.go --
+//go:build ignore_me
+
+package constrained
+
+func Unreachable() string {
+	return "never compiled"
+}
+-- src/untested_bin.go --
+package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("nobody tests me")
+}
+`,
+		// Baseline coverage needs Bazel 9, which dropped WORKSPACE support, so
+		// this test's generated workspace must use bzlmod. A non-empty suffix is
+		// what opts it in; no extra dependencies are required.
+		ModuleFileSuffix: `
+# Intentionally empty.
+`,
+	})
+}
+
+// record returns the lines of the LCOV record for path, or nil when the report
+// has no record for it.
+func record(t *testing.T, report, path string) []string {
+	t.Helper()
+
+	var out []string
+	inRecord := false
+	for _, line := range strings.Split(report, "\n") {
+		switch {
+		case line == "SF:"+path:
+			inRecord = true
+			out = nil
+		case inRecord && line == "end_of_record":
+			return out
+		case inRecord:
+			out = append(out, line)
+		}
+	}
+	return nil
+}
+
+func has(lines []string, want string) bool {
+	for _, line := range lines {
+		if line == want {
+			return true
+		}
+	}
+	return false
+}
+
+func TestBaselineCoverage(t *testing.T) {
+	if err := bazel_testing.RunBazel(
+		"coverage",
+		"--combined_report=lcov",
+		"//src:all",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	raw, err := os.ReadFile(filepath.FromSlash("bazel-out/_coverage/_coverage_report.dat"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	report := string(raw)
+
+	t.Run("untested library reports its coverable lines as missed", func(t *testing.T) {
+		lines := record(t, report, "src/untested.go")
+		if lines == nil {
+			t.Fatal("expected a record for src/untested.go, found none")
+		}
+		// Every line of Sum's body, none of them executed.
+		for _, want := range []string{"DA:3,0", "DA:4,0", "DA:5,0", "DA:6,0", "DA:8,0", "LH:0", "LF:6"} {
+			if !has(lines, want) {
+				t.Errorf("expected %q in the record for src/untested.go: %v", want, lines)
+			}
+		}
+	})
+
+	t.Run("untested binary reports its coverable lines as missed", func(t *testing.T) {
+		lines := record(t, report, "src/untested_bin.go")
+		if lines == nil {
+			t.Fatal("expected a record for src/untested_bin.go, found none")
+		}
+		if !has(lines, "LH:0") || has(lines, "LF:0") {
+			t.Errorf("expected src/untested_bin.go to report missed lines: %v", lines)
+		}
+	})
+
+	t.Run("declaration-only file has nothing to cover", func(t *testing.T) {
+		lines := record(t, report, "src/declarations.go")
+		if lines == nil {
+			t.Fatal("expected a record for src/declarations.go, found none")
+		}
+		if !has(lines, "LF:0") {
+			t.Errorf("expected LF:0 for src/declarations.go: %v", lines)
+		}
+	})
+
+	t.Run("build-constrained file is not reported", func(t *testing.T) {
+		if lines := record(t, report, "src/constrained.go"); lines != nil {
+			t.Errorf("expected no record for src/constrained.go, got %v", lines)
+		}
+	})
+
+	t.Run("measured coverage is not displaced by the baseline", func(t *testing.T) {
+		lines := record(t, report, "src/tested.go")
+		if lines == nil {
+			t.Fatal("expected a record for src/tested.go, found none")
+		}
+		if !has(lines, "DA:3,1") {
+			t.Errorf("expected the measured count DA:3,1 for src/tested.go: %v", lines)
+		}
+		if has(lines, "LH:0") {
+			t.Errorf("expected src/tested.go to report hits: %v", lines)
+		}
+	})
+}

--- a/tests/core/coverage/baseline_coverage_test.go
+++ b/tests/core/coverage/baseline_coverage_test.go
@@ -59,6 +59,15 @@ go_library(
     importpath = "example.com/declarations",
 )
 
+# cgo sources are instrumented before cgo rewrites them, exactly as a measured
+# coverage run instruments them, so the line numbers agree.
+go_library(
+    name = "untested_cgo",
+    srcs = ["untested_cgo.go"],
+    cgo = True,
+    importpath = "example.com/untestedcgo",
+)
+
 # Excluded by a build constraint that never matches, so it must not be reported
 # as uncovered.
 go_library(
@@ -115,6 +124,17 @@ package constrained
 
 func Unreachable() string {
 	return "never compiled"
+}
+-- src/untested_cgo.go --
+package untestedcgo
+
+import "C"
+
+func Describe(n int) string {
+	if n > 0 {
+		return "positive"
+	}
+	return "not positive"
 }
 -- src/untested_bin.go --
 package main
@@ -199,6 +219,20 @@ func TestBaselineCoverage(t *testing.T) {
 		}
 		if !has(lines, "LH:0") || has(lines, "LF:0") {
 			t.Errorf("expected src/untested_bin.go to report missed lines: %v", lines)
+		}
+	})
+
+	t.Run("untested cgo library reports the line numbers of its unprocessed source", func(t *testing.T) {
+		lines := record(t, report, "src/untested_cgo.go")
+		if lines == nil {
+			t.Fatal("expected a record for src/untested_cgo.go, found none")
+		}
+		// Describe's body, at the positions cmd/cover records before cgo
+		// rewrites the file. A measured run reports these same positions.
+		for _, want := range []string{"DA:5,0", "DA:6,0", "DA:7,0", "DA:8,0", "DA:9,0", "LH:0", "LF:5"} {
+			if !has(lines, want) {
+				t.Errorf("expected %q in the record for src/untested_cgo.go: %v", want, lines)
+			}
 		}
 	})
 


### PR DESCRIPTION
**What type of PR is this?**

> Bug fix

**What does this PR do? Why is it needed?**

rules_go doesn't pass baseline coverage files, so Bazel falls back to `BaselineCoverageAction`, which writes only the path and `end_of_record`. An untested package lands in the report as `LF:0 / LH:0`, which is also what a file with genuinely nothing to cover looks like. Consumers can't distinguish them, so 0/0 gets scored as 100% and a package with no tests scores better than one with partial tests.

This runs `cmd/cover` over the target's own `srcs`, reads back the block position table it appends, and emits LCOV with every coverable line at count 0, handed to Bazel via `baseline_coverage_files`. For an untested library:

```diff
 SF:src/untested.go
-FNF:0
-FNH:0
-LF:0
+DA:4,0
+DA:5,0
+DA:6,0
+DA:7,0
+LF:4
 LH:0
 end_of_record
```

**Which issues(s) does this PR fix?**

Fixes #4668

**Other notes for review**

It's 879 lines, but only 85 touch existing files. The rest is one builder action, one `.bzl`, and the tests.

The choices most likely to draw questions:

- The line set comes from `cmd/cover` rather than a separate AST pass, so the baseline agrees with measured output by construction rather than by approximation. `cover -pkgcfg` with `EmitMetaFile` is the mechanism `go test -cover` uses for a package with no test files, which is exactly this situation, and `covdata textfmt` decodes the result into the same text profile `bzltestutil` already consumes. I tried an AST generator first, and against a file whose real coverage run gives `LF:21` it emitted 14 lines, missing `case` clauses, continuation lines of multi-line statements, and closing braces.
- `covdata` is built from the SDK's own sources in the same action that already builds `pack` that way, since Go 1.25 dropped both prebuilt binaries from the distribution to shrink it. The shared Go build cache makes the extra build roughly a second, and a `covdata` compiled from its own SDK decodes whatever that SDK emits.
- This adds an optional `covdata` attribute to `go_toolchain`. Custom toolchain definitions that omit it simply emit no baseline, so nothing breaks for them.
- `Local: true` makes `cmd/cover` record each source under the exec-root-relative name it was given, so no path mapping round trip is needed. It changes only the recorded name, not the block positions.
- An empty meta-data file is the signal that a package has no coverable lines, which is structural rather than reconstructed from the sources. An absent one fails the action, so a future change to `EmitMetaFile` cannot quietly report `LF:0` everywhere.
- LCOV writing is hand-rolled, and the profile pattern is duplicated from `bzltestutil`, because `builder` is a `go_tool_binary` limited to the standard library and `bzltestutil` imports `coverdata`.
- `go_test` is deliberately untouched, since emitting baselines for `_test.go` files would regress results by scoring test files. Embedded libraries are unaffected, as the `go_library` they come from emits its own baseline from its own `srcs`. The gap this leaves is a non-test `.go` file that lives only in a `go_test`'s `srcs`, which gets no baseline. Happy to close that by filtering test files out of the test's own srcs if you'd prefer.
- Sources come from `ctx.files.srcs`, not `go_info.srcs`, to match `source_attributes = ["srcs"]`. `go_info.srcs` would pull in the generated coverage shim and embedded srcs, adding bogus and duplicate records.
- Files with nothing to cover still get an `SF:` record with `LF:0`, so the set of files in the report is unchanged. The zero is now measured rather than assumed.
- cgo files get baselines like any other source. `compilepkg` instruments them before cgo rewrites them, so a measured run reports positions in the unprocessed file, which are the ones this action reads back.
- The action is path mapped under exactly the condition `compilepkg` uses, and skips it for cgo and for targets tagged `local`. The two have to agree, since a generated source under `--experimental_output_paths=strip` would otherwise get a stripped path in the baseline and an unstripped one from the compile action, leaving the zeros in a record measured data never displaces.

This is guarded on `bazel_features.rules.instrumented_files_info_has_baseline_coverage_files`, and no dependency bump is needed since the current 1.36.0 pin already has that flag. On Bazel 7 and 8 the kwarg isn't passed and behaviour is unchanged. The `polyfill_bazel_features.bzl` value is a constant `False`, since Bazel 9 is also the release that removed WORKSPACE support.

Nothing runs on ordinary builds. The action is gated on `go.coverage_enabled` and `go.coverage_instrumented`, so `--instrumentation_filter` is respected too.

The `go_bazel_test` covers an untested library, an untested binary, an untested cgo library, a declaration-only file, a build-constrained file, and that measured coverage isn't displaced. It runs in CI on the Bazel 9 legs, and on Bazel 8 the `bazel_features` gate makes it incompatible so a `//...` pattern skips it. A unit test covers the profile reader. I also ran this across a ~680-file Go monorepo: same set of files in the report, measured coverage byte-identical, and 21 files that had been reporting 100% now report 0%.
