### PR TITLE
`gopackagesdriver_test`: add reproducer for stdlib race issue

### DIFF
--- a/go/tools/gopackagesdriver/gopackagesdriver_test.go
+++ b/go/tools/gopackagesdriver/gopackagesdriver_test.go
@@ -114,6 +114,22 @@ func main() {
 package unattached
 
 // not mentioned in any target
+
+-- race/BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_test")
+
+go_test(
+    name = "race_test",
+    srcs = ["race_test.go"],
+    race = "on",
+)
+
+-- race/race_test.go --
+package race
+
+import "testing"
+
+func TestRace(t *testing.T) {}
 `,
 	})
 }
@@ -383,6 +399,33 @@ func TestIncompatible(t *testing.T) {
 
 func TestUnattached(t *testing.T) {
 	runForTestExpectError(t, "found no labels matching the requests", packages.DriverRequest{}, ".", "file=unattached.go")
+}
+
+// TestStdlibRaceMode is a reproducer test (see related issue) to check that a
+// race-mode target does not leave stdlib file lists in an unbuildable state.
+func TestStdlibRaceMode(t *testing.T) {
+	const raceConstPkg = "internal/runtime/sys" 
+	const raceConstFile = "consts_race.go"
+	resp := runForTest(t, packages.DriverRequest{Tests: true}, "race", "./...")
+
+	var pkg *packages.Package
+	for _, p := range resp.Packages {
+		if p.PkgPath == raceConstPkg {
+			pkg = p
+			break
+		}
+	}
+	if pkg == nil {
+		t.Fatalf("response does not contain %s", raceConstPkg)
+	}
+
+	for _, file := range pkg.CompiledGoFiles {
+		if path.Base(file) == raceConstFile {
+			return
+		}
+	}
+
+	t.Errorf("%s: expected to contain '%s' in gotten pkg.goCompiledGoFiles: %v", raceConstPkg, raceConstFile, pkg.CompiledGoFiles)
 }
 
 func runForTest(


### PR DESCRIPTION
**What type of PR is this?**

> Other

This is just a reproducer containing a broken test meant for https://github.com/bazel-contrib/rules_go/issues/4683, please see discussion/details there

```
$ bazel test //go/tools/gopackagesdriver:gopackagesdriver_test --test_filter=TestStdlibRaceMode --test_output=all

...
==================== Test output for //go/tools/gopackagesdriver:gopackagesdriver_test:
Running: [bazel info --tool_tag=gopackagesdriver --ui_actions_shown=0]
Starting local Bazel server and connecting to it...
Running: [bazel query --tool_tag=gopackagesdriver --ui_actions_shown=0 --consistent_labels --ui_event_filters=-info,-stderr --noshow_progress --order_output=no --output=label --nodep_deps --noimplicit_deps --notool_deps kind("^(go_library|go_test) rule$", race/...)]
Running: [bazel build --tool_tag=gopackagesdriver --ui_actions_shown=0 --show_result=0 --build_event_json_file=/tmp/gopackagesdriver_bep_823480380 --build_event_json_file_path_conversion=no --experimental_convenience_symlinks=ignore --ui_event_filters=-info,-stderr --noshow_progress --aspects=@io_bazel_rules_go//go/tools/gopackagesdriver:aspect.bzl%go_pkg_info_aspect --output_groups=go_pkg_driver_json_file,go_pkg_driver_stdlib_json_file,go_pkg_driver_stdlib_cache_dir,go_pkg_driver_srcs --keep_going @//race:race_test]
--- FAIL: TestStdlibRaceMode (3.19s)
    gopackagesdriver_test.go:439: internal/runtime/sys: expected to contain 'consts_race.go' in gotten pkg.goCompiledGoFiles: [/home/andreanardelli/.cache/bazel/_bazel_andreanardelli/d50df819b40f5d06364585fdeeba87cb/external/go_sdk/src/internal/runtime/sys/consts.go /home/andreanardelli/.cache/bazel/_bazel_andreanardelli/d50df819b40f5d06364585fdeeba87cb/external/go_sdk/src/internal/runtime/sys/intrinsics.go /home/andreanardelli/.cache/bazel/_bazel_andreanardelli/d50df819b40f5d06364585fdeeba87cb/external/go_sdk/src/internal/runtime/sys/nih.go /home/andreanardelli/.cache/bazel/_bazel_andreanardelli/d50df819b40f5d06364585fdeeba87cb/external/go_sdk/src/internal/runtime/sys/no_dit.go /home/andreanardelli/.cache/bazel/_bazel_andreanardelli/d50df819b40f5d06364585fdeeba87cb/external/go_sdk/src/internal/runtime/sys/sys.go /home/andreanardelli/.cache/bazel/_bazel_andreanardelli/d50df819b40f5d06364585fdeeba87cb/external/go_sdk/src/internal/runtime/sys/zversion.go]
FAIL
================================================================================
```