### PR TITLE
Reserve CPUs for GoStdlib and hold it to them

### DIFF
--- a/go/private/actions/stdlib.bzl
+++ b/go/private/actions/stdlib.bzl
@@ -91,6 +91,20 @@ def _build_stdlib_list_json(go):
     )
     return out, cache_dir
 
+# GOMAXPROCS below pins the action to this, so the reservation is what the
+# action actually uses rather than an estimate. Kept well under the core count
+# on purpose: compiling the standard library stops getting faster at around six
+# cores, and letting several GoStdlib actions run with a slice each finishes a
+# batch sooner than giving one action the whole machine.
+_STDLIB_CPUS = 4
+
+# Around 250MB per action at that many threads, plus headroom for the extra a
+# compiler holds on to when it is given a PGO profile.
+_STDLIB_MEMORY_MB = 512
+
+def _stdlib_resource_set(_os, _inputs_size):
+    return {"cpu": _STDLIB_CPUS, "memory": _STDLIB_MEMORY_MB}
+
 def _stdlib_execution_requirements(go):
     # Non-pure stdlib actions run cgo and pass C toolchain paths through
     # CGO_CFLAGS/CGO_LDFLAGS. Bazel does not path-map environment values.
@@ -170,6 +184,12 @@ def _build_stdlib(go):
         args.add("-pgoprofile", go.mode.pgoprofile)
         inputs_direct.append(go.mode.pgoprofile)
 
+    env = dict(_build_env(go))
+
+    # "go install" defaults to one compiler per core; hold it to what was
+    # reserved for the action.
+    env["GOMAXPROCS"] = str(_STDLIB_CPUS)
+
     outputs = [pkg]
     go.actions.run(
         inputs = depset(direct = inputs_direct, transitive = inputs_transitive),
@@ -177,9 +197,10 @@ def _build_stdlib(go):
         mnemonic = "GoStdlib",
         executable = go.toolchain._builder,
         arguments = [args],
-        env = _build_env(go),
+        env = env,
         toolchain = GO_TOOLCHAIN_LABEL,
         execution_requirements = _stdlib_execution_requirements(go),
+        resource_set = _stdlib_resource_set,
     )
     list_json, cache_dir = _build_stdlib_list_json(go)
     return GoStdLib(


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

A single `GoStdlib` action runs `go install`, which compiles the standard library with one compiler per core (`-p` defaults to `runtime.GOMAXPROCS(0)`, `cmd/go/internal/cfg/cfg.go`). Bazel estimates one CPU for the action, so it schedules as many `GoStdlib` actions at once as the machine has cores, and each of those then tries to use the whole machine.

This declares a `resource_set` of four CPUs for the action and pins `GOMAXPROCS` to the same number, so the reservation is accurate rather than an estimate Bazel has no way to enforce.

**Which issues(s) does this PR fix?**

None filed.

**Other notes for review**

Measured on a 16 core M3 Max (12P + 4E) building 8 distinct standard library configurations — `linkmode` x `race` x `pure` plus two cross-compiled platforms — through `bazel build`. Each round salts every target with a different stdlib-affecting build tag so all 8 actions are fresh work rather than cache hits. Best of two interleaved passes:

| reservation | wall | peak RSS |
| --- | --- | --- |
| none (Bazel default) | 26.4s | 2085 MB |
| 2 CPUs | 28.7s | 1343 MB |
| 4 CPUs | 27.3s | 984 MB |
| 8 CPUs | 32.8s | 647 MB |
| 16 CPUs | 50.2s | 678 MB |

Worth being blunt about what this does and does not buy: **the current default is already close to optimal for wall time on this machine**, and reserving more only makes things worse — serializing the actions costs 24 seconds. What changes is peak memory, which halves, and the fact that concurrency becomes bounded at all. Today's estimate places no ceiling on how many standard library builds run at once, so on a 64 core executor it permits 64 of them each spawning 64 compilers. That is the shape of the out-of-memory reports.

Pinning `GOMAXPROCS` turned out to matter more than the reservation itself. At 4 CPUs without the pin I measured 29.6s and roughly 1.5 GB; with it, 27.3s and 984 MB — faster *and* leaner. A single stdlib build stops getting faster at around six cores:

| GOMAXPROCS | 1 | 2 | 3 | 5 | 6 | 8 | 12 | 16 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| wall | 29.1s | 13.9s | 10.7s | 9.3s | 7.2s | 6.6s | 6.6s | 6.9s |

so threads 7 through 16 were only adding contention and resident memory. The pin also makes the declared value true on any machine instead of a number that happens to be right on a 16 core host.

Caveats:

- One machine and one topology. The knee may sit elsewhere on a many-core server part, and 4 is chosen as the flattest point rather than a sharp optimum.
- The 512 MB memory figure is the softest number here: about 250 MB per action measured at four threads, doubled for headroom because a PGO profile leaves each compiler holding more. It should not bind on normal machines (4 concurrent x 512 MB against a 48 GB pool here); it is there as a floor for RAM-poor ones.
- `resource_set` only affects local execution scheduling. Remote executors need their own resource hints; this does not attempt to set any.
- Adding `GOMAXPROCS` to the action environment changes the `GoStdlib` action key, so standard libraries rebuild once after this lands.

Leaving as a draft for CI, and because the choice of 4 is worth a second opinion from someone who can run the same measurement on a larger machine. The benchmark harness is not included in the PR; happy to share it if that would help.
