### PR TITLE
Inherit static and pure settings for Go tool binaries

### DIFF
--- a/docs/go/core/rules.md
+++ b/docs/go/core/rules.md
@@ -298,6 +298,11 @@ generate should be subject to Nogo's static analysis. This is helpful, for examp
 a tool isn't built as a shared library with race instrumentation. This acts as an
 intermediate rule that allows users to apply these transitions.
 
+The '//go/config:static' and '//go/config:pure' settings are an exception: they are
+inherited from the value set on the command line, as they determine whether the tool
+can run on the execution platform. The 'static' and 'pure' attributes of an enclosing
+rule are still reset.
+
 **ATTRIBUTES**
 
 

--- a/go/config/BUILD.bazel
+++ b/go/config/BUILD.bazel
@@ -5,9 +5,12 @@ load(
     "string_list_flag",
 )
 
+# Universally scoped as Go tool binaries have to run on the execution platform,
+# which may only be able to run statically linked binaries.
 bool_flag(
     name = "static",
     build_setting_default = False,
+    scope = "universal",
     visibility = ["//visibility:public"],
 )
 
@@ -23,9 +26,11 @@ bool_flag(
     visibility = ["//visibility:public"],
 )
 
+# Universally scoped for the same reason as :static.
 bool_flag(
     name = "pure",
     build_setting_default = False,
+    scope = "universal",
     visibility = ["//visibility:public"],
 )
 

--- a/go/private/rules/BUILD.bazel
+++ b/go/private/rules/BUILD.bazel
@@ -2,6 +2,7 @@ load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
 load("@bazel_skylib//rules:common_settings.bzl", "string_setting")
 load(
     ":transition.bzl",
+    "TOOL_INHERITED_SETTING_KEYS",
     "TRANSITIONED_GO_SETTING_KEYS",
 )
 
@@ -14,6 +15,9 @@ exports_files([
     string_setting(
         name = "original_" + setting.split(":")[1],
         build_setting_default = "",
+        # Must have the same scope as the setting it records, or
+        # go_tool_transition can't tell a command-line value from an attribute.
+        scope = "universal" if setting in TOOL_INHERITED_SETTING_KEYS else None,
         visibility = ["//visibility:private"],
     )
     for setting in TRANSITIONED_GO_SETTING_KEYS

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -59,6 +59,22 @@ _SETTING_KEY_TO_ORIGINAL_SETTING_KEY = {
     for setting in TRANSITIONED_GO_SETTING_KEYS
 }
 
+# Settings that go_tool_transition inherits from the command line instead of
+# resetting: whether a binary has to be linked statically or without cgo is a
+# property of the platform it runs on, so it applies to Go tool binaries as much
+# as to the target the user requested.
+TOOL_INHERITED_SETTING_KEYS = [
+    "//go/config:static",
+    "//go/config:pure",
+]
+
+def _setting_before_go_transition(settings, key):
+    """Returns the value of key from before the last go_transition."""
+    original_value = settings[_SETTING_KEY_TO_ORIGINAL_SETTING_KEY[key]]
+    if original_value:
+        return json.decode(original_value)
+    return settings[key]
+
 def _go_transition_impl(settings, attr):
     # NOTE: Keep the list of rules_go settings set by this transition in sync
     # with POTENTIALLY_TRANSITIONED_SETTINGS.
@@ -213,8 +229,14 @@ def _go_tool_transition_impl(settings, _attr):
     doesn't change the platform (goos, goarch), but tool binaries should also
     have `cfg = "exec"` so tool binaries should be built for the execution
     platform.
+
+    The settings in TOOL_INHERITED_SETTING_KEYS are an exception: they keep the
+    value they had before the last go_transition.
     """
-    return dict(settings, **_reset_transition_dict)
+    new_settings = dict(settings, **_reset_transition_dict)
+    for key in TOOL_INHERITED_SETTING_KEYS:
+        new_settings[key] = _setting_before_go_transition(settings, key)
+    return new_settings
 
 go_tool_transition = transition(
     implementation = _go_tool_transition_impl,
@@ -229,7 +251,9 @@ def _non_go_tool_transition_impl(settings, _attr):
     nogo settings to their default values. This is used for all tools that are
     not themselves targets created from rules_go rules and thus do not read
     these settings. Resetting all of them to defaults prevents unnecessary
-    configuration changes for these targets that could cause rebuilds.
+    configuration changes for these targets that could cause rebuilds. Unlike
+    go_tool_transition, it also resets TOOL_INHERITED_SETTING_KEYS: how a Go
+    binary is linked is irrelevant for a tool that isn't one.
 
     Examples: This transition is applied to attributes referencing proto_library
     targets or protoc directly.
@@ -327,6 +351,11 @@ target configuration and neither the tools nor the code they potentially
 generate should be subject to Nogo's static analysis. This is helpful, for example, so
 a tool isn't built as a shared library with race instrumentation. This acts as an
 intermediate rule that allows users to apply these transitions.
+
+The '//go/config:static' and '//go/config:pure' settings are an exception: they are
+inherited from the value set on the command line, as they determine whether the tool
+can run on the execution platform. The 'static' and 'pure' attributes of an enclosing
+rule are still reset.
 """,
 )
 
@@ -369,12 +398,7 @@ def _non_go_transition_impl(settings, _attr):
     """
     new_settings = {}
     for key, original_key in _SETTING_KEY_TO_ORIGINAL_SETTING_KEY.items():
-        original_value = settings[original_key]
-        if original_value:
-            # Reset to the original value of the setting before go_transition.
-            new_settings[key] = json.decode(original_value)
-        else:
-            new_settings[key] = settings[key]
+        new_settings[key] = _setting_before_go_transition(settings, key)
 
         # Reset the value of the helper setting to its default for two reasons:
         # 1. Performance: This ensures that the Go settings of non-Go

--- a/tests/core/transition/BUILD.bazel
+++ b/tests/core/transition/BUILD.bazel
@@ -11,3 +11,9 @@ go_bazel_test(
     size = "medium",
     srcs = ["hermeticity_test.go"],
 )
+
+go_bazel_test(
+    name = "tool_settings_test",
+    size = "medium",
+    srcs = ["tool_settings_test.go"],
+)

--- a/tests/core/transition/tool_settings_test.go
+++ b/tests/core/transition/tool_settings_test.go
@@ -1,0 +1,228 @@
+// Copyright 2026 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tool_settings_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
+)
+
+func TestMain(m *testing.M) {
+	bazel_testing.TestMain(m, bazel_testing.Args{
+		Main: `
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "nogo")
+
+nogo(
+    name = "my_nogo",
+    vet = True,
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "lib",
+    srcs = ["lib.go"],
+    importpath = "example.com/lib",
+)
+
+go_binary(
+    name = "plain",
+    srcs = ["main.go"],
+    deps = [":lib"],
+)
+
+go_binary(
+    name = "static_attr",
+    srcs = ["main.go"],
+    static = "on",
+    deps = [":lib"],
+)
+
+go_binary(
+    name = "pure_attr",
+    srcs = ["main.go"],
+    pure = "on",
+    deps = [":lib"],
+)
+-- main.go --
+package main
+
+func main() {}
+-- lib.go --
+package lib
+`,
+		ModuleFileSuffix: `
+go_sdk = use_extension("@io_bazel_rules_go//go:extensions.bzl", "go_sdk")
+go_sdk.nogo(nogo = "//:my_nogo")
+`,
+	})
+}
+
+// TestCommandLineSettingsReachTools verifies that a value set on the command
+// line applies to Go tool binaries. Tools have to run on the execution
+// platform, so one that is linked dynamically against a libc that isn't
+// installed there breaks the build. See #4378.
+func TestCommandLineSettingsReachTools(t *testing.T) {
+	for _, setting := range []string{"static", "pure"} {
+		t.Run(setting, func(t *testing.T) {
+			got := nogoGoOptions(t, "//:plain", "--@io_bazel_rules_go//go/config:"+setting)
+			want := setting + "=true"
+			if !contains(got, want) {
+				t.Errorf("nogo is not built with %s: got %s", want, strings.Join(got, ", "))
+			}
+		})
+	}
+}
+
+// TestCommandLineSettingsReachToolsWithExcludedStarlarkFlags verifies the same
+// for Bazel's upcoming default of not propagating Starlark flags into the exec
+// configuration, which the settings opt out of via scope = "universal".
+func TestCommandLineSettingsReachToolsWithExcludedStarlarkFlags(t *testing.T) {
+	const excludeFlag = "--incompatible_exclude_starlark_flags_from_exec_config"
+	if err := bazel_testing.RunBazel("build", "//:plain", "--nobuild", excludeFlag); err != nil {
+		// The flag only exists on Bazel 9+. On older versions, skip rather than
+		// fail so the test stays green across the supported Bazel matrix.
+		if strings.Contains(err.Error(), "Unrecognized option: "+excludeFlag) {
+			t.Skipf("Bazel does not support %s; skipping", excludeFlag)
+		}
+		t.Fatalf("bazel build //:plain %s: %v", excludeFlag, err)
+	}
+
+	for _, setting := range []string{"static", "pure"} {
+		t.Run(setting, func(t *testing.T) {
+			got := nogoGoOptions(t, "//:plain", excludeFlag, "--@io_bazel_rules_go//go/config:"+setting)
+			if want := setting + "=true"; !contains(got, want) {
+				t.Errorf("nogo is not built with %s: got %s", want, strings.Join(got, ", "))
+			}
+		})
+		t.Run(setting+"_attr", func(t *testing.T) {
+			got := nogoGoOptions(t, "//:"+setting+"_attr", excludeFlag)
+			if contains(got, setting+"=true") {
+				t.Errorf("nogo inherited %s from the rule attribute: got %s", setting, strings.Join(got, ", "))
+			}
+		})
+	}
+}
+
+// TestRuleAttributesDoNotReachTools verifies that the static and pure
+// attributes of an individual rule do not propagate to Go tool binaries, which
+// would build one copy of every tool per distinct attribute value.
+func TestRuleAttributesDoNotReachTools(t *testing.T) {
+	for _, setting := range []string{"static", "pure"} {
+		t.Run(setting, func(t *testing.T) {
+			got := nogoGoOptions(t, "//:"+setting+"_attr")
+			if contains(got, setting+"=true") {
+				t.Errorf("nogo inherited %s from the rule attribute: got %s", setting, strings.Join(got, ", "))
+			}
+		})
+	}
+}
+
+// nogoGoOptions returns the rules_go settings that the nogo binary reachable
+// from target is configured with and that differ from their default value.
+func nogoGoOptions(t *testing.T, target string, flags ...string) []string {
+	// Analyze the targets to ensure that MODULE.bazel.lock has been created,
+	// otherwise bazel config will fail after the cquery command due to the
+	// Skyframe invalidation caused by a changed file.
+	if err := bazel_testing.RunBazel(append([]string{"build", target, "--nobuild"}, flags...)...); err != nil {
+		t.Fatalf("bazel build %s: %v", target, err)
+	}
+
+	query := fmt.Sprintf("deps(%s) intersect //:my_nogo_actual", target)
+	out, err := bazel_testing.BazelOutput(append(
+		[]string{"cquery", "--output=jsonproto", query},
+		flags...,
+	)...)
+	if err != nil {
+		t.Fatalf("bazel cquery '%s': %v", query, err)
+	}
+	hashes := extractConfigHashes(t, bytes.TrimSpace(out))
+	if len(hashes) == 0 {
+		t.Fatalf("%s does not depend on //:my_nogo_actual", target)
+	}
+	if len(hashes) > 1 {
+		// bazel config only reports the options the configs differ in.
+		if diff := getGoOptions(t, hashes...); len(diff) != 0 {
+			t.Fatalf("%s depends on //:my_nogo_actual in configs differing in: %s",
+				target, strings.Join(diff, ", "))
+		}
+	}
+	return getGoOptions(t, hashes[0])
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+func extractConfigHashes(t *testing.T, rawJSONOut []byte) []string {
+	var jsonOut struct {
+		Results []struct {
+			Configuration struct {
+				Checksum string `json:"checksum"`
+			} `json:"configuration"`
+		} `json:"results"`
+	}
+	if err := json.Unmarshal(rawJSONOut, &jsonOut); err != nil {
+		t.Fatalf("Failed to decode bazel cquery JSON output %v: %q", err, string(rawJSONOut))
+	}
+	var hashes []string
+	for _, result := range jsonOut.Results {
+		hashes = append(hashes, result.Configuration.Checksum)
+	}
+	return hashes
+}
+
+func getGoOptions(t *testing.T, hashes ...string) []string {
+	out, err := bazel_testing.BazelOutput(append([]string{"config", "--output=json"}, hashes...)...)
+	if err != nil {
+		t.Fatalf("bazel config %s: %v", strings.Join(hashes, " "), err)
+	}
+	var jsonOut struct {
+		Fragments []struct {
+			Name    string            `json:"name"`
+			Options map[string]string `json:"options"`
+		} `json:"fragmentOptions"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(out), &jsonOut); err != nil {
+		t.Fatalf("Failed to decode bazel config JSON output %v: %q", err, string(out))
+	}
+	// The repository part of the keys depends on the canonical repository name,
+	// so only keep the part that identifies the setting.
+	const configPkg = "//go/config:"
+	var goOptions []string
+	for _, fragment := range jsonOut.Fragments {
+		if fragment.Name != "user-defined" {
+			continue
+		}
+		for key, value := range fragment.Options {
+			if _, name, found := strings.Cut(key, configPkg); found {
+				goOptions = append(goOptions, fmt.Sprintf("%s=%s", name, value))
+			}
+		}
+	}
+	sort.Strings(goOptions)
+	return goOptions
+}


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`go_tool_transition` resets all `//go/config` settings to their default values, so a value set on the command line never reaches Go tool binaries such as `nogo`. Whether a binary has to be linked statically or without cgo is a property of the platform it runs on rather than of the particular target the user requested, so when the execution platform can only run statically linked binaries (a musl-only CI image being the reported case), those tools end up dynamically linked and fail.

This restores `//go/config:static` and `//go/config:pure` to the value they had before the last `go_transition`, which is the value set on the command line. Values set by the `static` and `pure` attributes of an individual rule are still reset, so tools continue to be built in a single configuration no matter how many distinct attribute values the build contains. That is the difference to the workaround in #4378, which drops the keys from `_reset_transition_dict` entirely and therefore builds one copy of every tool per attribute value.

`non_go_tool_transition` keeps the full reset: how a Go binary is linked is irrelevant for a tool that isn't one, and Go proto plugins go through `go_reset_target` rather than `non_go_tool_transition`, so `protoc` and `proto_library` stay in a single configuration regardless of the Go settings.

Both settings and their `original_*` shadow settings are scoped as `universal` so that they keep reaching tools under `--incompatible_exclude_starlark_flags_from_exec_config` (default in Bazel 10). Both halves are required: with the scope missing on a shadow setting, the value propagates into the exec configuration while the shadow setting resets, `go_tool_transition` can no longer tell a value set on the command line from one set by a rule attribute, and the attribute leaks into the tool configuration.

**Which issues(s) does this PR fix?**

Fixes #4378

**Other notes for review**

`--@rules_go//go/config:static` now applies to exec-configured Go tools, which seems right to me and can also be overridden via `flags` on `platform`.