### PR TITLE
link: add package path to build info

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -178,6 +178,7 @@ def emit_link(
 
     builder_args.add("-o", executable)
     builder_args.add("-main", archive.data.file)
+    builder_args.add("-main_package_path", archive.data.importpath)
     builder_args.add("-p", archive.data.importmap)
     tool_args.add_all(gc_linkopts)
     tool_args.add_all(go.toolchain.flags.link)

--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -189,8 +189,8 @@ func buildInfoDeps(modules []moduleInfo) []*debug.Module {
 	return deps
 }
 
-func modInfoData(modules []moduleInfo) string {
-	info := &debug.BuildInfo{Deps: buildInfoDeps(modules)}
+func modInfoData(path string, modules []moduleInfo) string {
+	info := &debug.BuildInfo{Path: path, Deps: buildInfoDeps(modules)}
 	return buildInfoStart + info.String() + buildInfoEnd
 }
 

--- a/go/tools/builders/buildinfo_test.go
+++ b/go/tools/builders/buildinfo_test.go
@@ -180,14 +180,14 @@ func TestBuildInfoDepsSortAndDedup(t *testing.T) {
 }
 
 func TestModInfoDataRoundTrip(t *testing.T) {
-	info := parseModInfoData(t, modInfoData([]moduleInfo{
+	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", []moduleInfo{
 		{path: "golang.org/x/sync", version: "v0.8.0"},
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 	}))
 
-	if info.Path != "" {
-		t.Fatalf("got Path %q; want empty", info.Path)
+	if info.Path != "example.com/cmd/tool" {
+		t.Fatalf("got Path %q; want %q", info.Path, "example.com/cmd/tool")
 	}
 	if info.Main.Path != "" || info.Main.Version != "" {
 		t.Fatalf("got Main %+v; want empty", info.Main)
@@ -207,23 +207,37 @@ func TestModInfoDataRoundTrip(t *testing.T) {
 }
 
 func TestModInfoDataWithoutDeps(t *testing.T) {
-	info := parseModInfoData(t, modInfoData(nil))
+	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", nil))
+	if info.Path != "example.com/cmd/tool" {
+		t.Fatalf("got Path %q; want %q", info.Path, "example.com/cmd/tool")
+	}
 	if len(info.Deps) != 0 {
 		t.Fatalf("got %d deps; want 0", len(info.Deps))
 	}
 }
 
 func TestModInfoDataFormat(t *testing.T) {
-	got := modInfoData([]moduleInfo{
+	got := modInfoData("example.com/cmd/tool", []moduleInfo{
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 		{path: "golang.org/x/sync", version: "v0.8.0"},
 	})
 	want := buildInfoStart +
+		"path\texample.com/cmd/tool\n" +
 		"dep\tgithub.com/google/go-cmp\tv0.6.0\t\n" +
 		"dep\tgolang.org/x/sync\tv0.8.0\t\n" +
 		buildInfoEnd
 	if got != want {
 		t.Fatalf("got %q; want %q", got, want)
+	}
+}
+
+func TestModInfoDataWithoutPathOrDeps(t *testing.T) {
+	info := parseModInfoData(t, modInfoData("", nil))
+	if info.Path != "" {
+		t.Fatalf("got Path %q; want empty", info.Path)
+	}
+	if len(info.Deps) != 0 {
+		t.Fatalf("got %d deps; want 0", len(info.Deps))
 	}
 }
 

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -43,6 +43,7 @@ func link(args []string) error {
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
 	main := flags.String("main", "", "Path to the main archive.")
+	mainPackagePath := flags.String("main_package_path", "", "Import path of the main package.")
 	packagePath := flags.String("p", "", "Package path of the main archive.")
 	outFile := flags.String("o", "", "Path to output file.")
 	flags.Var(&archives, "arc", "Label, package path, and file name of a dependency, separated by '='")
@@ -98,7 +99,7 @@ func link(args []string) error {
 		if err != nil {
 			return err
 		}
-		modinfo = modInfoData(modules)
+		modinfo = modInfoData(*mainPackagePath, modules)
 	}
 	importcfgName, err := buildImportcfgFileForLink(archives, *packageList, goenv.installSuffix, filepath.Dir(*outFile), modinfo)
 	if err != nil {

--- a/tests/core/go_binary/buildinfo_test.go
+++ b/tests/core/go_binary/buildinfo_test.go
@@ -84,6 +84,7 @@ type dep struct {
 
 type output struct {
     OK          bool   ` + "`json:\"ok\"`" + `
+    Path        string ` + "`json:\"path\"`" + `
     MainPath    string ` + "`json:\"main_path\"`" + `
     MainVersion string ` + "`json:\"main_version\"`" + `
     Deps        []dep  ` + "`json:\"deps\"`" + `
@@ -95,6 +96,7 @@ func main() {
     info, ok := debug.ReadBuildInfo()
     out := output{OK: ok}
     if info != nil {
+        out.Path = info.Path
         out.MainPath = info.Main.Path
         out.MainVersion = info.Main.Version
         for _, module := range info.Deps {
@@ -147,6 +149,7 @@ import (
 
 type output struct {
     OK          bool   ` + "`json:\"ok\"`" + `
+    Path        string ` + "`json:\"path\"`" + `
     MainPath    string ` + "`json:\"main_path\"`" + `
     MainVersion string ` + "`json:\"main_version\"`" + `
     DepCount    int    ` + "`json:\"dep_count\"`" + `
@@ -156,6 +159,7 @@ func main() {
     info, ok := debug.ReadBuildInfo()
     out := output{OK: ok}
     if info != nil {
+        out.Path = info.Path
         out.MainPath = info.Main.Path
         out.MainVersion = info.Main.Version
         out.DepCount = len(info.Deps)
@@ -181,6 +185,7 @@ type dep struct {
 
 type output struct {
     OK          bool   ` + "`json:\"ok\"`" + `
+    Path        string ` + "`json:\"path\"`" + `
     MainPath    string ` + "`json:\"main_path\"`" + `
     MainVersion string ` + "`json:\"main_version\"`" + `
     Deps        []dep  ` + "`json:\"deps\"`" + `
@@ -192,6 +197,7 @@ func main() {
     info, ok := debug.ReadBuildInfo()
     out := output{OK: ok}
     if info != nil {
+        out.Path = info.Path
         out.MainPath = info.Main.Path
         out.MainVersion = info.Main.Version
         for _, module := range info.Deps {
@@ -360,6 +366,7 @@ type dep struct {
 
 type withDepOutput struct {
 	OK          bool   `json:"ok"`
+	Path        string `json:"path"`
 	MainPath    string `json:"main_path"`
 	MainVersion string `json:"main_version"`
 	Deps        []dep  `json:"deps"`
@@ -367,6 +374,7 @@ type withDepOutput struct {
 
 type stdlibOnlyOutput struct {
 	OK          bool   `json:"ok"`
+	Path        string `json:"path"`
 	MainPath    string `json:"main_path"`
 	MainVersion string `json:"main_version"`
 	DepCount    int    `json:"dep_count"`
@@ -384,6 +392,9 @@ func TestReadBuildInfoDeps(t *testing.T) {
 	}
 	if !got.OK {
 		t.Fatalf("ReadBuildInfo returned ok=false: %+v", got)
+	}
+	if got.Path != "with_dep" {
+		t.Fatalf("got Path %q; want %q", got.Path, "with_dep")
 	}
 	if got.MainPath != "" || got.MainVersion != "" {
 		t.Fatalf("got Main %q %q; want empty", got.MainPath, got.MainVersion)
@@ -428,6 +439,9 @@ func TestReadBuildInfoWithoutMetadata(t *testing.T) {
 	if !got.OK {
 		t.Fatalf("ReadBuildInfo returned ok=false: %+v", got)
 	}
+	if got.Path != "stdlib_only" {
+		t.Fatalf("got Path %q; want %q", got.Path, "stdlib_only")
+	}
 	if got.MainPath != "" || got.MainVersion != "" {
 		t.Fatalf("got Main %q %q; want empty", got.MainPath, got.MainVersion)
 	}
@@ -460,6 +474,9 @@ func TestReadBuildInfoVersionlessDep(t *testing.T) {
 	}
 	if !got.OK {
 		t.Fatalf("ReadBuildInfo returned ok=false: %+v", got)
+	}
+	if got.Path != "with_versionless_dep" {
+		t.Fatalf("got Path %q; want %q", got.Path, "with_versionless_dep")
 	}
 
 	foundVersionless := false


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

Binaries built with rules_go leave `BuildInfo.Path` empty even though
analysis knows the main archive import path. `go version -m` and
`runtime/debug` clients use this field to identify the main package, as
they do for binaries built with `cmd/go`.

Pass the main package import path to the linker and serialize it with
Go 1.20's `debug.BuildInfo.String` API. Extend the builder and
end-to-end tests to cover binaries with and without dependency metadata.

This builds on #4595 and is deliberately limited to `BuildInfo.Path`;
main-module identity and build settings will be proposed separately.

**Which issues(s) does this PR fix?**

Part of #3090.

**Other notes for review**

None.
