### PR TITLE
link: add build settings to build info

### DIFF
--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -71,8 +71,10 @@ def emit_link(
 
     # Add in any mode specific behaviours
     if go.mode.race:
+        builder_args.add("-race")
         tool_args.add("-race")
     if go.mode.msan:
+        builder_args.add("-msan")
         tool_args.add("-msan")
 
     if go.mode.pure:
@@ -138,6 +140,8 @@ def emit_link(
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
     builder_args.add_all(package_metadata_files, before_each = "-package_metadata")
     builder_args.add("-package_list", go.sdk.package_list)
+    if go.coverage_enabled:
+        builder_args.add("-cover")
 
     # Build a list of rpaths for dynamic libraries we need to find.
     # rpaths are relative paths from the binary to directories where libraries

--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -189,8 +189,119 @@ func buildInfoDeps(modules []moduleInfo) []*debug.Module {
 	return deps
 }
 
-func modInfoData(path string, modules []moduleInfo) string {
-	info := &debug.BuildInfo{Path: path, Deps: buildInfoDeps(modules)}
+func buildInfoSettings(buildmode string, buildTags []string, race, msan, cover, go123ArchSettings bool) []debug.BuildSetting {
+	return buildInfoSettingsFromEnv(buildmode, buildTags, race, msan, cover, go123ArchSettings, os.Getenv)
+}
+
+func buildInfoSettingsFromEnv(buildmode string, buildTags []string, race, msan, cover, go123ArchSettings bool, getenv func(string) string) []debug.BuildSetting {
+	if buildmode == "" || buildmode == "normal" {
+		buildmode = "exe"
+	}
+
+	settings := []debug.BuildSetting{
+		{Key: "-buildmode", Value: buildmode},
+		{Key: "-compiler", Value: "gc"},
+	}
+	if cover {
+		settings = append(settings, debug.BuildSetting{Key: "-cover", Value: "true"})
+	}
+	if msan {
+		settings = append(settings, debug.BuildSetting{Key: "-msan", Value: "true"})
+	}
+	if race {
+		settings = append(settings, debug.BuildSetting{Key: "-race", Value: "true"})
+	}
+	if buildTags = buildInfoTags(buildTags, race, msan); len(buildTags) > 0 {
+		settings = append(settings, debug.BuildSetting{Key: "-tags", Value: strings.Join(buildTags, ",")})
+	}
+	settings = append(settings, debug.BuildSetting{Key: "-trimpath", Value: "true"})
+
+	goarch := ""
+	for _, key := range []string{"CGO_ENABLED", "GOARCH", "GOEXPERIMENT", "GOOS"} {
+		if value := getenv(key); value != "" {
+			if key == "GOARCH" {
+				goarch = value
+			}
+			settings = append(settings, debug.BuildSetting{Key: key, Value: value})
+		}
+	}
+	if key, value := buildInfoArchSetting(goarch, go123ArchSettings, getenv); key != "" && value != "" {
+		settings = append(settings, debug.BuildSetting{Key: key, Value: value})
+	}
+	return settings
+}
+
+func buildInfoTags(buildTags []string, race, msan bool) []string {
+	if len(buildTags) == 0 {
+		return nil
+	}
+	filtered := append([]string(nil), buildTags...)
+	if race {
+		filtered = stripLastBuildTag(filtered, "race")
+	}
+	if msan {
+		filtered = stripLastBuildTag(filtered, "msan")
+	}
+	return filtered
+}
+
+func stripLastBuildTag(buildTags []string, want string) []string {
+	for i := len(buildTags) - 1; i >= 0; i-- {
+		if buildTags[i] == want {
+			return append(buildTags[:i], buildTags[i+1:]...)
+		}
+	}
+	return buildTags
+}
+
+func buildInfoArchSetting(goarch string, go123ArchSettings bool, getenv func(string) string) (string, string) {
+	switch goarch {
+	case "386":
+		return "GO386", firstNonEmpty(getenv("GO386"), "sse2")
+	case "amd64":
+		return "GOAMD64", firstNonEmpty(getenv("GOAMD64"), "v1")
+	case "arm":
+		if value := getenv("GOARM"); value != "" {
+			return "GOARM", value
+		}
+		if getenv("GOOS") == "android" {
+			return "GOARM", "7"
+		}
+		// The Go SDK's default GOARM may be detected when the SDK is built.
+		// Omit it when unknown instead of deriving it from the execution platform.
+	case "arm64":
+		if go123ArchSettings {
+			return "GOARM64", firstNonEmpty(getenv("GOARM64"), "v8.0")
+		}
+	case "mips", "mipsle":
+		return "GOMIPS", firstNonEmpty(getenv("GOMIPS"), "hardfloat")
+	case "mips64", "mips64le":
+		return "GOMIPS64", firstNonEmpty(getenv("GOMIPS64"), "hardfloat")
+	case "ppc64", "ppc64le":
+		return "GOPPC64", firstNonEmpty(getenv("GOPPC64"), "power8")
+	case "riscv64":
+		if go123ArchSettings {
+			return "GORISCV64", firstNonEmpty(getenv("GORISCV64"), "rva20u64")
+		}
+	case "wasm":
+		if value := getenv("GOWASM"); value != "" {
+			return "GOWASM", value
+		}
+	}
+	return "", ""
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func modInfoData(path string, settings []debug.BuildSetting, modules []moduleInfo) string {
+	info := &debug.BuildInfo{Path: path, Deps: buildInfoDeps(modules), Settings: settings}
 	return buildInfoStart + info.String() + buildInfoEnd
 }
 

--- a/go/tools/builders/buildinfo_test.go
+++ b/go/tools/builders/buildinfo_test.go
@@ -180,7 +180,12 @@ func TestBuildInfoDepsSortAndDedup(t *testing.T) {
 }
 
 func TestModInfoDataRoundTrip(t *testing.T) {
-	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", []moduleInfo{
+	settings := []debug.BuildSetting{
+		{Key: "-buildmode", Value: "exe"},
+		{Key: "-compiler", Value: "gc"},
+		{Key: "GOARCH", Value: "arm64"},
+	}
+	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", settings, []moduleInfo{
 		{path: "golang.org/x/sync", version: "v0.8.0"},
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
@@ -204,10 +209,13 @@ func TestModInfoDataRoundTrip(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got deps %v; want %v", got, want)
 	}
+	if !reflect.DeepEqual(info.Settings, settings) {
+		t.Fatalf("got settings %+v; want %+v", info.Settings, settings)
+	}
 }
 
 func TestModInfoDataWithoutDeps(t *testing.T) {
-	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", nil))
+	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", nil, nil))
 	if info.Path != "example.com/cmd/tool" {
 		t.Fatalf("got Path %q; want %q", info.Path, "example.com/cmd/tool")
 	}
@@ -217,7 +225,10 @@ func TestModInfoDataWithoutDeps(t *testing.T) {
 }
 
 func TestModInfoDataFormat(t *testing.T) {
-	got := modInfoData("example.com/cmd/tool", []moduleInfo{
+	got := modInfoData("example.com/cmd/tool", []debug.BuildSetting{
+		{Key: "-buildmode", Value: "exe"},
+		{Key: "-tags", Value: "foo,bar"},
+	}, []moduleInfo{
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 		{path: "golang.org/x/sync", version: "v0.8.0"},
 	})
@@ -225,6 +236,8 @@ func TestModInfoDataFormat(t *testing.T) {
 		"path\texample.com/cmd/tool\n" +
 		"dep\tgithub.com/google/go-cmp\tv0.6.0\t\n" +
 		"dep\tgolang.org/x/sync\tv0.8.0\t\n" +
+		"build\t-buildmode=exe\n" +
+		"build\t-tags=foo,bar\n" +
 		buildInfoEnd
 	if got != want {
 		t.Fatalf("got %q; want %q", got, want)
@@ -232,12 +245,91 @@ func TestModInfoDataFormat(t *testing.T) {
 }
 
 func TestModInfoDataWithoutPathOrDeps(t *testing.T) {
-	info := parseModInfoData(t, modInfoData("", nil))
+	info := parseModInfoData(t, modInfoData("", nil, nil))
 	if info.Path != "" {
 		t.Fatalf("got Path %q; want empty", info.Path)
 	}
 	if len(info.Deps) != 0 {
 		t.Fatalf("got %d deps; want 0", len(info.Deps))
+	}
+	if len(info.Settings) != 0 {
+		t.Fatalf("got %d settings; want 0", len(info.Settings))
+	}
+}
+
+func TestBuildInfoSettingsFromEnv(t *testing.T) {
+	env := map[string]string{
+		"CGO_ENABLED":  "1",
+		"GOARCH":       "amd64",
+		"GOEXPERIMENT": "rangefunc",
+		"GOOS":         "linux",
+		"GOAMD64":      "v3",
+	}
+	got := buildInfoSettingsFromEnv("pie", []string{"foo", "race", "bar"}, true, false, true, false, func(key string) string {
+		return env[key]
+	})
+	want := []debug.BuildSetting{
+		{Key: "-buildmode", Value: "pie"},
+		{Key: "-compiler", Value: "gc"},
+		{Key: "-cover", Value: "true"},
+		{Key: "-race", Value: "true"},
+		{Key: "-tags", Value: "foo,bar"},
+		{Key: "-trimpath", Value: "true"},
+		{Key: "CGO_ENABLED", Value: "1"},
+		{Key: "GOARCH", Value: "amd64"},
+		{Key: "GOEXPERIMENT", Value: "rangefunc"},
+		{Key: "GOOS", Value: "linux"},
+		{Key: "GOAMD64", Value: "v3"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got settings %+v; want %+v", got, want)
+	}
+}
+
+func TestBuildInfoSettingsPreservesExplicitInstrumentationTags(t *testing.T) {
+	got := buildInfoSettingsFromEnv("normal", []string{"race", "foo", "race"}, true, false, false, false, func(string) string {
+		return ""
+	})
+	want := []debug.BuildSetting{
+		{Key: "-buildmode", Value: "exe"},
+		{Key: "-compiler", Value: "gc"},
+		{Key: "-race", Value: "true"},
+		{Key: "-tags", Value: "race,foo"},
+		{Key: "-trimpath", Value: "true"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("got settings %+v; want %+v", got, want)
+	}
+}
+
+func TestBuildInfoArchSetting(t *testing.T) {
+	testCases := []struct {
+		name              string
+		goarch            string
+		go123ArchSettings bool
+		env               map[string]string
+		wantKey           string
+		wantValue         string
+	}{
+		{name: "amd64 default", goarch: "amd64", wantKey: "GOAMD64", wantValue: "v1"},
+		{name: "arm default unknown", goarch: "arm"},
+		{name: "arm android default", goarch: "arm", env: map[string]string{"GOOS": "android"}, wantKey: "GOARM", wantValue: "7"},
+		{name: "arm explicit", goarch: "arm", env: map[string]string{"GOARM": "6"}, wantKey: "GOARM", wantValue: "6"},
+		{name: "arm64 before Go 1.23", goarch: "arm64"},
+		{name: "arm64 from Go 1.23", goarch: "arm64", go123ArchSettings: true, wantKey: "GOARM64", wantValue: "v8.0"},
+		{name: "riscv64 before Go 1.23", goarch: "riscv64"},
+		{name: "riscv64 from Go 1.23", goarch: "riscv64", go123ArchSettings: true, wantKey: "GORISCV64", wantValue: "rva20u64"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotKey, gotValue := buildInfoArchSetting(tc.goarch, tc.go123ArchSettings, func(key string) string {
+				return tc.env[key]
+			})
+			if gotKey != tc.wantKey || gotValue != tc.wantValue {
+				t.Fatalf("got %q=%q; want %q=%q", gotKey, gotValue, tc.wantKey, tc.wantValue)
+			}
+		})
 	}
 }
 

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -21,6 +21,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"go/build"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -44,6 +45,9 @@ func link(args []string) error {
 	goenv := envFlags(flags)
 	main := flags.String("main", "", "Path to the main archive.")
 	mainPackagePath := flags.String("main_package_path", "", "Import path of the main package.")
+	race := flags.Bool("race", false, "Whether race instrumentation is enabled.")
+	msan := flags.Bool("msan", false, "Whether memory sanitizer instrumentation is enabled.")
+	cover := flags.Bool("cover", false, "Whether coverage instrumentation is enabled.")
 	packagePath := flags.String("p", "", "Package path of the main archive.")
 	outFile := flags.String("o", "", "Path to output file.")
 	flags.Var(&archives, "arc", "Label, package path, and file name of a dependency, separated by '='")
@@ -56,6 +60,10 @@ func link(args []string) error {
 		return err
 	}
 	if err := goenv.checkFlagsAndSetGoroot(); err != nil {
+		return err
+	}
+	go123OrLater, err := onVersion(23)
+	if err != nil {
 		return err
 	}
 
@@ -99,7 +107,11 @@ func link(args []string) error {
 		if err != nil {
 			return err
 		}
-		modinfo = modInfoData(*mainPackagePath, modules)
+		modinfo = modInfoData(
+			*mainPackagePath,
+			buildInfoSettings(*buildmode, build.Default.BuildTags, *race, *msan, *cover, go123OrLater),
+			modules,
+		)
 	}
 	importcfgName, err := buildImportcfgFileForLink(archives, *packageList, goenv.installSuffix, filepath.Dir(*outFile), modinfo)
 	if err != nil {
@@ -168,11 +180,7 @@ func link(args []string) error {
 	goargs = append(goargs, toolArgs...)
 	goargs = append(goargs, *main)
 
-	clearGoRoot, err := onVersion(23)
-	if err != nil {
-		return err
-	}
-	if clearGoRoot {
+	if go123OrLater {
 		// Explicitly set GOROOT to a dummy value when running linker.
 		// This ensures that the GOROOT written into the binary
 		// is constant and thus builds are reproducible.

--- a/tests/core/go_binary/buildinfo_test.go
+++ b/tests/core/go_binary/buildinfo_test.go
@@ -16,6 +16,7 @@ package buildinfo_test
 
 import (
 	"encoding/json"
+	"runtime"
 	"testing"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel_testing"
@@ -83,11 +84,20 @@ type dep struct {
 }
 
 type output struct {
-    OK          bool   ` + "`json:\"ok\"`" + `
-    Path        string ` + "`json:\"path\"`" + `
-    MainPath    string ` + "`json:\"main_path\"`" + `
-    MainVersion string ` + "`json:\"main_version\"`" + `
-    Deps        []dep  ` + "`json:\"deps\"`" + `
+    OK          bool              ` + "`json:\"ok\"`" + `
+    Path        string            ` + "`json:\"path\"`" + `
+    MainPath    string            ` + "`json:\"main_path\"`" + `
+    MainVersion string            ` + "`json:\"main_version\"`" + `
+    Settings    map[string]string ` + "`json:\"settings\"`" + `
+    Deps        []dep             ` + "`json:\"deps\"`" + `
+}
+
+func buildSettings(info *debug.BuildInfo) map[string]string {
+    settings := make(map[string]string, len(info.Settings))
+    for _, setting := range info.Settings {
+        settings[setting.Key] = setting.Value
+    }
+    return settings
 }
 
 func main() {
@@ -99,6 +109,7 @@ func main() {
         out.Path = info.Path
         out.MainPath = info.Main.Path
         out.MainVersion = info.Main.Version
+        out.Settings = buildSettings(info)
         for _, module := range info.Deps {
             out.Deps = append(out.Deps, dep{Path: module.Path, Version: module.Version})
         }
@@ -365,11 +376,12 @@ type dep struct {
 }
 
 type withDepOutput struct {
-	OK          bool   `json:"ok"`
-	Path        string `json:"path"`
-	MainPath    string `json:"main_path"`
-	MainVersion string `json:"main_version"`
-	Deps        []dep  `json:"deps"`
+	OK          bool              `json:"ok"`
+	Path        string            `json:"path"`
+	MainPath    string            `json:"main_path"`
+	MainVersion string            `json:"main_version"`
+	Settings    map[string]string `json:"settings"`
+	Deps        []dep             `json:"deps"`
 }
 
 type stdlibOnlyOutput struct {
@@ -395,6 +407,21 @@ func TestReadBuildInfoDeps(t *testing.T) {
 	}
 	if got.Path != "with_dep" {
 		t.Fatalf("got Path %q; want %q", got.Path, "with_dep")
+	}
+	if got.Settings["-buildmode"] != expectedBuildMode() {
+		t.Fatalf("got -buildmode %q; want %q", got.Settings["-buildmode"], expectedBuildMode())
+	}
+	if got.Settings["-compiler"] != "gc" {
+		t.Fatalf("got -compiler %q; want gc", got.Settings["-compiler"])
+	}
+	if got.Settings["-trimpath"] != "true" {
+		t.Fatalf("got -trimpath %q; want true", got.Settings["-trimpath"])
+	}
+	if got.Settings["GOOS"] != runtime.GOOS {
+		t.Fatalf("got GOOS %q; want %q", got.Settings["GOOS"], runtime.GOOS)
+	}
+	if got.Settings["GOARCH"] != runtime.GOARCH {
+		t.Fatalf("got GOARCH %q; want %q", got.Settings["GOARCH"], runtime.GOARCH)
 	}
 	if got.MainPath != "" || got.MainVersion != "" {
 		t.Fatalf("got Main %q %q; want empty", got.MainPath, got.MainVersion)
@@ -423,6 +450,30 @@ func TestReadBuildInfoDeps(t *testing.T) {
 		if dep.Path == "example.com/main" {
 			t.Fatalf("binary's own metadata was included as a dependency: %+v", got.Deps)
 		}
+	}
+}
+
+func expectedBuildMode() string {
+	switch runtime.GOOS {
+	case "android", "darwin", "ios", "windows":
+		return "pie"
+	default:
+		return "exe"
+	}
+}
+
+func TestReadBuildInfoTags(t *testing.T) {
+	stdout, err := bazel_testing.BazelOutput("run", "--@io_bazel_rules_go//go/config:tags=foo,bar", "//:with_dep")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got withDepOutput
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout, err)
+	}
+	if got.Settings["-tags"] != "foo,bar" {
+		t.Fatalf("got -tags %q; want foo,bar", got.Settings["-tags"])
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

rules_go build information omits the configuration that produced a binary. `go version -m` and `runtime/debug` clients use these settings to distinguish binaries built for different modes, targets, and instrumentation.

Record deterministic settings already known to the link action. Use the Go 1.20 `debug.BuildSetting` and `BuildInfo.String` APIs, filter tags added internally for instrumentation, avoid deriving unknown `GOARM` defaults from the execution platform, and emit ARM64 and RISC-V tuning only for Go 1.23 or later.

This builds on #4690 and is deliberately limited to `BuildInfo.Settings`; main-module identity and VCS settings will be proposed separately.

**Which issues(s) does this PR fix?**

Part of #3090.

**Other notes for review**

None.