### PR TITLE
link: add main module to build info

### DIFF
--- a/go/private/actions/binary.bzl
+++ b/go/private/actions/binary.bzl
@@ -35,11 +35,17 @@ def emit_binary(
         version_file = None,
         info_file = None,
         executable = None,
-        link_exec_group = None):
+        link_exec_group = None,
+        buildinfo_main_package_path = None,
+        buildinfo_module_metadata = None):
     """See go/toolchains.rst#binary for full documentation."""
 
     if name == "" and executable == None:
         fail("either name or executable must be set")
+    if buildinfo_main_package_path == None:
+        buildinfo_main_package_path = source.importpath
+    if buildinfo_module_metadata == None:
+        buildinfo_module_metadata = getattr(source, "_package_metadata", None)
 
     archive = go.archive(go, source)
     if not executable:
@@ -58,6 +64,8 @@ def emit_binary(
         go,
         archive = archive,
         test_archives = test_archives,
+        buildinfo_main_package_path = buildinfo_main_package_path,
+        buildinfo_module_metadata = buildinfo_module_metadata,
         executable = executable,
         gc_linkopts = gc_linkopts,
         version_file = version_file,

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -45,13 +45,19 @@ def emit_link(
         gc_linkopts = [],
         version_file = None,
         info_file = None,
-        exec_group = None):
+        exec_group = None,
+        buildinfo_main_package_path = None,
+        buildinfo_module_metadata = None):
     """See go/toolchains.rst#link for full documentation."""
 
     if archive == None:
         fail("archive is a required parameter")
     if executable == None:
         fail("executable is a required parameter")
+    if buildinfo_main_package_path == None:
+        buildinfo_main_package_path = archive.data.importpath
+    if buildinfo_module_metadata == None:
+        buildinfo_module_metadata = getattr(archive.data, "_package_metadata", None)
 
     # Exclude -lstdc++ from link options. We don't want to link against it
     # unless we actually have some C++ code. _cgo_codegen will include it
@@ -182,7 +188,9 @@ def emit_link(
 
     builder_args.add("-o", executable)
     builder_args.add("-main", archive.data.file)
-    builder_args.add("-main_package_path", archive.data.importpath)
+    builder_args.add("-main_package_path", buildinfo_main_package_path)
+    if buildinfo_module_metadata:
+        builder_args.add("-main_module_metadata", buildinfo_module_metadata)
     builder_args.add("-p", archive.data.importmap)
     tool_args.add_all(gc_linkopts)
     tool_args.add_all(go.toolchain.flags.link)
@@ -194,6 +202,8 @@ def emit_link(
     tool_args.add_joined("-extldflags", extldflags, join_with = " ")
 
     inputs_direct = stamp_inputs + [go.sdk.package_list]
+    if buildinfo_module_metadata:
+        inputs_direct.append(buildinfo_module_metadata)
     if go.coverage_enabled and go.coverdata:
         inputs_direct.append(go.coverdata.data.file)
     inputs_transitive = [

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -376,7 +376,6 @@ def new_go_info(
         generated_srcs = [],
         pathtype = None,
         deps = None,
-        include_package_metadata = True,
         verify_resolver_deps = False):
     if not importpath:
         importpath = go.importpath
@@ -400,12 +399,10 @@ def new_go_info(
     if deps == None:
         deps = [get_archive(dep) for dep in getattr(attr, "deps", [])]
 
-    package_metadata = None
-    if include_package_metadata:
-        package_metadata = package_metadata_file_from_metadata(
-            getattr(attr, "package_metadata", ()),
-            getattr(attr, "applicable_licenses", ()),
-        )
+    package_metadata = package_metadata_file_from_metadata(
+        getattr(attr, "package_metadata", ()),
+        getattr(attr, "applicable_licenses", ()),
+    )
 
     go_info = {
         "name": go.label.name if not name else name,
@@ -436,9 +433,6 @@ def new_go_info(
 
     for e in getattr(attr, "embed", []):
         _merge_embed(go_info, e)
-
-    if not include_package_metadata:
-        go_info["_package_metadata"] = None
 
     go_info["deps"] = _dedup_archives(go_info["deps"])
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -78,7 +78,6 @@ def _go_test_impl(ctx):
         go,
         ctx.attr,
         testfilter = "exclude",
-        include_package_metadata = False,
     )
     internal_archive = go.archive(go, internal_go_info)
     if internal_archive.data._validation_output:
@@ -189,6 +188,8 @@ def _go_test_impl(ctx):
         name = ctx.label.name,
         source = test_go_info,
         test_archives = [internal_archive.data],
+        buildinfo_main_package_path = internal_go_info.importpath + ".test" if internal_go_info.importpath else None,
+        buildinfo_module_metadata = getattr(internal_go_info, "_package_metadata", None),
         gc_linkopts = test_gc_linkopts,
         version_file = ctx.version_file,
         info_file = ctx.info_file,

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -768,6 +768,9 @@ embedding, cgo dependencies, coverage, and assembling and packing .s files.
 It returns a tuple containing GoArchive_, the output executable file, and
 a ``runfiles`` object.
 
+.. |main package path| replace:: :param:`buildinfo_main_package_path`
+.. |module metadata| replace:: :param:`buildinfo_module_metadata`
+
 +--------------------------------+-----------------------------+-----------------------------------+
 | **Name**                       | **Type**                    | **Default value**                 |
 +--------------------------------+-----------------------------+-----------------------------------+
@@ -803,6 +806,15 @@ a ``runfiles`` object.
 +--------------------------------+-----------------------------+-----------------------------------+
 | Optional output file to write. If not set, ``binary`` will generate an output                    |
 | file name based on ``name``, the target platform, and the link mode.                             |
++--------------------------------+-----------------------------+-----------------------------------+
+| |main package path|            | :type:`string`              | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| Main package path recorded in ``runtime/debug.BuildInfo``. Defaults to ``source.importpath``.    |
++--------------------------------+-----------------------------+-----------------------------------+
+| |module metadata|              | :type:`File`                | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| Package metadata JSON file used to populate ``BuildInfo.Main``. Defaults to the metadata         |
+| propagated by :param:`source`.                                                                   |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 
@@ -846,6 +858,15 @@ It does not return anything.
 | :param:`info_file`             | :type:`File`                | :value:`None`                     |
 +--------------------------------+-----------------------------+-----------------------------------+
 | Info file used for link stamping.                                                                |
++--------------------------------+-----------------------------+-----------------------------------+
+| |main package path|            | :type:`string`              | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| Main package path recorded in ``runtime/debug.BuildInfo``. Defaults to the archive import path.  |
++--------------------------------+-----------------------------+-----------------------------------+
+| |module metadata|              | :type:`File`                | :value:`None`                     |
++--------------------------------+-----------------------------+-----------------------------------+
+| Package metadata JSON file used to populate ``BuildInfo.Main``. Defaults to metadata propagated  |
+| by :param:`archive`.                                                                             |
 +--------------------------------+-----------------------------+-----------------------------------+
 
 

--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -155,7 +155,7 @@ func moduleFromPURL(purl string) (moduleInfo, bool, error) {
 	return moduleInfo{path: modulePath, version: moduleVersion}, true, nil
 }
 
-func buildInfoDeps(modules []moduleInfo) []*debug.Module {
+func buildInfoDeps(modules []moduleInfo, mainModule moduleInfo) []*debug.Module {
 	// Package metadata is not guaranteed to come from a single MVS-resolved
 	// module graph. Preserve distinct versions for the same path rather than
 	// silently choosing one when independently authored metadata conflicts.
@@ -163,6 +163,9 @@ func buildInfoDeps(modules []moduleInfo) []*debug.Module {
 	unique := make([]moduleInfo, 0, len(modules))
 	for _, module := range modules {
 		if module.path == "" || module.version == "" {
+			continue
+		}
+		if mainModule.path != "" && module.path == mainModule.path {
 			continue
 		}
 		if _, ok := seen[module]; ok {
@@ -187,6 +190,13 @@ func buildInfoDeps(modules []moduleInfo) []*debug.Module {
 		})
 	}
 	return deps
+}
+
+func buildInfoMain(module moduleInfo) debug.Module {
+	if module.path == "" {
+		return debug.Module{}
+	}
+	return debug.Module{Path: module.path, Version: module.version}
 }
 
 func buildInfoSettings(buildmode string, buildTags []string, race, msan, cover, go123ArchSettings bool) []debug.BuildSetting {
@@ -300,8 +310,13 @@ func firstNonEmpty(values ...string) string {
 	return ""
 }
 
-func modInfoData(path string, settings []debug.BuildSetting, modules []moduleInfo) string {
-	info := &debug.BuildInfo{Path: path, Deps: buildInfoDeps(modules), Settings: settings}
+func modInfoData(path string, mainModule moduleInfo, settings []debug.BuildSetting, modules []moduleInfo) string {
+	info := &debug.BuildInfo{
+		Path:     path,
+		Main:     buildInfoMain(mainModule),
+		Deps:     buildInfoDeps(modules, mainModule),
+		Settings: settings,
+	}
 	return buildInfoStart + info.String() + buildInfoEnd
 }
 

--- a/go/tools/builders/buildinfo_test.go
+++ b/go/tools/builders/buildinfo_test.go
@@ -163,7 +163,7 @@ func TestBuildInfoDepsSortAndDedup(t *testing.T) {
 		{path: "golang.org/x/text", version: "v0.16.0"},
 		{path: "", version: "v1.0.0"},
 		{path: "example.com/missing/version", version: ""},
-	})
+	}, moduleInfo{})
 
 	got := make([]string, 0, len(deps))
 	for _, dep := range deps {
@@ -185,7 +185,7 @@ func TestModInfoDataRoundTrip(t *testing.T) {
 		{Key: "-compiler", Value: "gc"},
 		{Key: "GOARCH", Value: "arm64"},
 	}
-	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", settings, []moduleInfo{
+	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", moduleInfo{}, settings, []moduleInfo{
 		{path: "golang.org/x/sync", version: "v0.8.0"},
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
@@ -214,8 +214,28 @@ func TestModInfoDataRoundTrip(t *testing.T) {
 	}
 }
 
+func TestModInfoDataMainModule(t *testing.T) {
+	info := parseModInfoData(t, modInfoData(
+		"example.com/cmd/tool",
+		moduleInfo{path: "example.com/main", version: "v1.2.3"},
+		nil,
+		[]moduleInfo{
+			{path: "example.com/main", version: "v1.2.3"},
+			{path: "example.com/main", version: "v1.1.0"},
+			{path: "example.com/dep", version: "v0.1.0"},
+		},
+	))
+
+	if info.Main.Path != "example.com/main" || info.Main.Version != "v1.2.3" {
+		t.Fatalf("got Main %+v; want example.com/main@v1.2.3", info.Main)
+	}
+	if len(info.Deps) != 1 || info.Deps[0].Path != "example.com/dep" {
+		t.Fatalf("got Deps %+v; want only example.com/dep", info.Deps)
+	}
+}
+
 func TestModInfoDataWithoutDeps(t *testing.T) {
-	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", nil, nil))
+	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", moduleInfo{}, nil, nil))
 	if info.Path != "example.com/cmd/tool" {
 		t.Fatalf("got Path %q; want %q", info.Path, "example.com/cmd/tool")
 	}
@@ -225,7 +245,7 @@ func TestModInfoDataWithoutDeps(t *testing.T) {
 }
 
 func TestModInfoDataFormat(t *testing.T) {
-	got := modInfoData("example.com/cmd/tool", []debug.BuildSetting{
+	got := modInfoData("example.com/cmd/tool", moduleInfo{}, []debug.BuildSetting{
 		{Key: "-buildmode", Value: "exe"},
 		{Key: "-tags", Value: "foo,bar"},
 	}, []moduleInfo{
@@ -245,7 +265,7 @@ func TestModInfoDataFormat(t *testing.T) {
 }
 
 func TestModInfoDataWithoutPathOrDeps(t *testing.T) {
-	info := parseModInfoData(t, modInfoData("", nil, nil))
+	info := parseModInfoData(t, modInfoData("", moduleInfo{}, nil, nil))
 	if info.Path != "" {
 		t.Fatalf("got Path %q; want empty", info.Path)
 	}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -44,7 +44,15 @@ func link(args []string) error {
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
 	main := flags.String("main", "", "Path to the main archive.")
+	// The main package path populates runtime/debug.BuildInfo.Path. For example,
+	// "golang.org/x/tools/cmd/stringer" identifies the executable package.
 	mainPackagePath := flags.String("main_package_path", "", "Import path of the main package.")
+	// The main module metadata flag instead names a package metadata JSON file,
+	// for example "bazel-out/.../package-metadata.json". A PURL such as
+	// "pkg:golang/golang.org/x/tools@v0.34.0" in that file populates
+	// BuildInfo.Main as golang.org/x/tools@v0.34.0. The package and module paths
+	// differ when the executable package is below the module root.
+	mainModuleMetadata := flags.String("main_module_metadata", "", "Path to the main module's package_metadata JSON file.")
 	race := flags.Bool("race", false, "Whether race instrumentation is enabled.")
 	msan := flags.Bool("msan", false, "Whether memory sanitizer instrumentation is enabled.")
 	cover := flags.Bool("cover", false, "Whether coverage instrumentation is enabled.")
@@ -107,8 +115,19 @@ func link(args []string) error {
 		if err != nil {
 			return err
 		}
+		mainModule := moduleInfo{}
+		if *mainModuleMetadata != "" {
+			mainModules, err := modulesFromPackageMetadataFiles([]string{*mainModuleMetadata})
+			if err != nil {
+				return err
+			}
+			if len(mainModules) > 0 {
+				mainModule = mainModules[0]
+			}
+		}
 		modinfo = modInfoData(
 			*mainPackagePath,
+			mainModule,
 			buildInfoSettings(*buildmode, build.Default.BuildTags, *race, *msan, *cover, go123OrLater),
 			modules,
 		)

--- a/tests/core/go_binary/buildinfo_test.go
+++ b/tests/core/go_binary/buildinfo_test.go
@@ -26,8 +26,9 @@ func TestMain(m *testing.M) {
 	bazel_testing.TestMain(m, bazel_testing.Args{
 		Main: `
 -- BUILD.bazel --
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_test")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
+load(":direct_link_binary.bzl", "direct_link_binary")
 
 package_metadata(
     name = "main_package_metadata",
@@ -44,6 +45,19 @@ go_binary(
     ],
 )
 
+go_library(
+    name = "embedded_main",
+    srcs = ["with_dep.go"],
+    importpath = "example.com/main/cmd/embedded_wrapper",
+    applicable_licenses = [":main_package_metadata"],
+    deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
+)
+
+go_binary(
+    name = "embedded_wrapper",
+    embed = [":embedded_main"],
+)
+
 go_test(
     name = "with_dep_test",
     srcs = ["with_dep_test.go"],
@@ -56,6 +70,13 @@ go_binary(
     srcs = ["stdlib_only.go"],
 )
 
+direct_link_binary(
+    name = "custom_direct_link",
+    srcs = ["stdlib_only.go"],
+    importpath = "example.com/main/cmd/custom_direct_link",
+    applicable_licenses = [":main_package_metadata"],
+)
+
 go_binary(
     name = "with_versionless_dep",
     srcs = ["with_versionless_dep.go"],
@@ -66,6 +87,43 @@ go_binary(
     name = "with_vendored_dep",
     srcs = ["with_vendored_dep.go"],
     deps = ["//third_party/vendored:vendored"],
+)
+-- direct_link_binary.bzl --
+load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_rule", "new_go_info")
+
+def _direct_link_binary_impl(ctx):
+    go = go_context(ctx, maybe_needs_cc_toolchain = False)
+    source = new_go_info(
+        go,
+        ctx.attr,
+        importable = False,
+        is_main = True,
+    )
+    archive = go.archive(go, source)
+    executable = go.actions.declare_file(ctx.label.name)
+    go.link(
+        go,
+        archive = archive,
+        executable = executable,
+        version_file = ctx.version_file,
+        info_file = ctx.info_file,
+    )
+    return [
+        archive,
+        DefaultInfo(
+            files = depset([executable]),
+            executable = executable,
+        ),
+    ]
+
+direct_link_binary = go_rule(
+    _direct_link_binary_impl,
+    executable = True,
+    attrs = {
+        "srcs": attr.label_list(allow_files = [".go"]),
+        "importpath": attr.string(mandatory = True),
+        "_go_context_data": attr.label(default = "@io_bazel_rules_go//:go_context_data"),
+    },
 )
 -- with_dep.go --
 package main
@@ -134,6 +192,9 @@ func TestBuildInfoDeps(t *testing.T) {
     if !ok {
         t.Fatal("ReadBuildInfo returned ok=false")
     }
+	if info.Main.Path != "example.com/main" || info.Main.Version != "v1.0.0" {
+		t.Fatalf("got Main %+v; want example.com/main@v1.0.0", info.Main)
+	}
 
     foundCmp := false
     for _, dep := range info.Deps {
@@ -423,8 +484,8 @@ func TestReadBuildInfoDeps(t *testing.T) {
 	if got.Settings["GOARCH"] != runtime.GOARCH {
 		t.Fatalf("got GOARCH %q; want %q", got.Settings["GOARCH"], runtime.GOARCH)
 	}
-	if got.MainPath != "" || got.MainVersion != "" {
-		t.Fatalf("got Main %q %q; want empty", got.MainPath, got.MainVersion)
+	if got.MainPath != "example.com/main" || got.MainVersion != "v1.0.0" {
+		t.Fatalf("got Main %q %q; want example.com/main v1.0.0", got.MainPath, got.MainVersion)
 	}
 	if len(got.Deps) == 0 {
 		t.Fatalf("got no deps: %+v", got)
@@ -449,6 +510,26 @@ func TestReadBuildInfoDeps(t *testing.T) {
 	for _, dep := range got.Deps {
 		if dep.Path == "example.com/main" {
 			t.Fatalf("binary's own metadata was included as a dependency: %+v", got.Deps)
+		}
+	}
+}
+
+func TestReadBuildInfoEmbeddedMain(t *testing.T) {
+	stdout, err := bazel_testing.BazelOutput("run", "//:embedded_wrapper")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got withDepOutput
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout, err)
+	}
+	if got.MainPath != "example.com/main" || got.MainVersion != "v1.0.0" {
+		t.Fatalf("got Main %q %q; want example.com/main v1.0.0", got.MainPath, got.MainVersion)
+	}
+	for _, dep := range got.Deps {
+		if dep.Path == "example.com/main" {
+			t.Fatalf("embedded main module was included as a dependency: %+v", got.Deps)
 		}
 	}
 }
@@ -498,6 +579,21 @@ func TestReadBuildInfoWithoutMetadata(t *testing.T) {
 	}
 	if got.DepCount != 0 {
 		t.Fatalf("got %d deps; want 0", got.DepCount)
+	}
+}
+
+func TestGoContextDirectLinkBuildInfo(t *testing.T) {
+	stdout, err := bazel_testing.BazelOutput("run", "//:custom_direct_link")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got stdlibOnlyOutput
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout, err)
+	}
+	if got.MainPath != "example.com/main" || got.MainVersion != "v1.0.0" {
+		t.Fatalf("got Main %q %q; want example.com/main v1.0.0", got.MainPath, got.MainVersion)
 	}
 }
 


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

rules_go records dependency modules in `BuildInfo.Deps`, but leaves
`BuildInfo.Main` empty even when package metadata identifies the module that
owns an executable. Build-info consumers therefore cannot report the main
module path and version.

This change passes two distinct values to the linker:

- The executable package's import path populates `BuildInfo.Path`.
- The Go PURL in its package metadata populates `BuildInfo.Main`.

Package metadata is kept unconditionally on `GoInfo` and archive data. At link
time, the target metadata is selected as the main module and that module path
is filtered from the candidate dependencies. This prevents a `go_test` binary
from reporting its own module in `BuildInfo.Deps` without a test-only
suppression flag or a duplicate provider field.

The new `go.binary` and `go.link` parameters are appended to preserve
positional compatibility for custom Starlark rules. Tests cover ordinary
binaries, embedded main packages, test binaries, binaries without metadata,
and direct `go.archive` to `go.link` callers.

**Which issue(s) does this PR fix?**

No linked issue.

**Other notes for review**

Build-info stack:

1. #4694 — add main-module build info (this PR)
2. #4695 — add stamped VCS build info

The second draft is cumulative against `master` because both heads are
fork-owned. It depends on this PR and is rebased after this PR changes.

Validation:

- `bazel --nohome_rc test //tests/...` — 467 passed, 1 Darwin-only test skipped
- `bazel test //go/tools/builders:all //tests/core/go_binary:buildinfo_test //tests/core/starlark:package_metadata_test //tests:buildifier_test`
- `bazel build //docs/...`
- `bazel test //docs/...`
- `git diff --check`
