### PR TITLE
link: preserve checksum qualifier from golang PURLs

### DIFF
--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -34,6 +34,7 @@ const (
 type moduleInfo struct {
 	path    string
 	version string
+	sum     string
 }
 
 type packageMetadata struct {
@@ -111,14 +112,13 @@ func modulesFromPackageMetadataFiles(paths []string) ([]moduleInfo, error) {
 }
 
 func moduleFromPURL(purl string) (moduleInfo, bool, error) {
-	const prefix = "pkg:golang/"
-	if !strings.HasPrefix(purl, prefix) {
-		return moduleInfo{}, false, nil
+	u, err := url.Parse(purl)
+	if err != nil {
+		return moduleInfo{}, false, fmt.Errorf("parsing Go package URL: %w", err)
 	}
-
-	value := strings.TrimPrefix(purl, prefix)
-	if i := strings.IndexAny(value, "?#"); i >= 0 {
-		value = value[:i]
+	value, ok := strings.CutPrefix(u.Opaque, "golang/")
+	if u.Scheme != "pkg" || !ok {
+		return moduleInfo{}, false, nil
 	}
 	if value == "" {
 		return moduleInfo{}, false, fmt.Errorf("Go package URL has an empty module path")
@@ -137,7 +137,6 @@ func moduleFromPURL(purl string) (moduleInfo, bool, error) {
 		return moduleInfo{}, false, fmt.Errorf("Go package URL has an empty module path")
 	}
 
-	var err error
 	modulePath, err = url.PathUnescape(modulePath)
 	if err != nil {
 		return moduleInfo{}, false, fmt.Errorf("unescaping Go module path: %w", err)
@@ -152,7 +151,16 @@ func moduleFromPURL(purl string) (moduleInfo, bool, error) {
 		}
 	}
 
-	return moduleInfo{path: modulePath, version: moduleVersion}, true, nil
+	var moduleSum string
+	if u.RawQuery != "" {
+		values, err := url.ParseQuery(u.RawQuery)
+		if err != nil {
+			return moduleInfo{}, false, fmt.Errorf("parsing Go package URL qualifiers: %w", err)
+		}
+		moduleSum = values.Get("checksum")
+	}
+
+	return moduleInfo{path: modulePath, version: moduleVersion, sum: moduleSum}, true, nil
 }
 
 func buildInfoDeps(modules []moduleInfo, mainModule moduleInfo) []*debug.Module {
@@ -179,7 +187,10 @@ func buildInfoDeps(modules []moduleInfo, mainModule moduleInfo) []*debug.Module 
 		if unique[i].path != unique[j].path {
 			return unique[i].path < unique[j].path
 		}
-		return unique[i].version < unique[j].version
+		if unique[i].version != unique[j].version {
+			return unique[i].version < unique[j].version
+		}
+		return unique[i].sum < unique[j].sum
 	})
 
 	deps := make([]*debug.Module, 0, len(unique))
@@ -187,6 +198,7 @@ func buildInfoDeps(modules []moduleInfo, mainModule moduleInfo) []*debug.Module 
 		deps = append(deps, &debug.Module{
 			Path:    module.path,
 			Version: module.version,
+			Sum:     module.sum,
 		})
 	}
 	return deps

--- a/go/tools/builders/buildinfo_test.go
+++ b/go/tools/builders/buildinfo_test.go
@@ -44,9 +44,15 @@ func TestModuleFromPURL(t *testing.T) {
 			wantOK: true,
 		},
 		{
-			name:   "normalizes version and strips qualifiers",
+			name:   "normalizes version and strips non-checksum qualifiers",
 			purl:   "pkg:golang/example.com/module@1.2.3?goos=linux#cmd/tool",
 			want:   moduleInfo{path: "example.com/module", version: "v1.2.3"},
+			wantOK: true,
+		},
+		{
+			name:   "preserves checksum qualifier",
+			purl:   "pkg:golang/example.com/module@1.2.3?checksum=h1:AbCd%2FEfGh%2BIjKl%3D",
+			want:   moduleInfo{path: "example.com/module", version: "v1.2.3", sum: "h1:AbCd/EfGh+IjKl="},
 			wantOK: true,
 		},
 		{
@@ -161,18 +167,23 @@ func TestBuildInfoDepsSortAndDedup(t *testing.T) {
 		{path: "github.com/google/go-cmp", version: "v0.6.0"},
 		{path: "golang.org/x/text", version: "v0.15.0"},
 		{path: "golang.org/x/text", version: "v0.16.0"},
+		{path: "example.com/module", version: "1.2.3", sum: "h1:aaa="},
+		{path: "example.com/module", version: "1.2.3", sum: "h1:aaa="},
+		{path: "example.com/module", version: "1.2.3", sum: "h1:bbb="},
 		{path: "", version: "v1.0.0"},
 		{path: "example.com/missing/version", version: ""},
 	}, moduleInfo{})
 
 	got := make([]string, 0, len(deps))
 	for _, dep := range deps {
-		got = append(got, dep.Path+"@"+dep.Version)
+		got = append(got, dep.Path+"@"+dep.Version+";"+dep.Sum)
 	}
 	want := []string{
-		"github.com/google/go-cmp@v0.6.0",
-		"golang.org/x/text@v0.15.0",
-		"golang.org/x/text@v0.16.0",
+		"example.com/module@1.2.3;h1:aaa=",
+		"example.com/module@1.2.3;h1:bbb=",
+		"github.com/google/go-cmp@v0.6.0;",
+		"golang.org/x/text@v0.15.0;",
+		"golang.org/x/text@v0.16.0;",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got deps %v; want %v", got, want)
@@ -186,9 +197,9 @@ func TestModInfoDataRoundTrip(t *testing.T) {
 		{Key: "GOARCH", Value: "arm64"},
 	}
 	info := parseModInfoData(t, modInfoData("example.com/cmd/tool", moduleInfo{}, settings, []moduleInfo{
-		{path: "golang.org/x/sync", version: "v0.8.0"},
-		{path: "github.com/google/go-cmp", version: "v0.6.0"},
-		{path: "github.com/google/go-cmp", version: "v0.6.0"},
+		{path: "golang.org/x/sync", version: "v0.8.0", sum: "h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ="},
+		{path: "github.com/google/go-cmp", version: "v0.6.0", sum: "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="},
+		{path: "github.com/google/go-cmp", version: "v0.6.0", sum: "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="},
 	}))
 
 	if info.Path != "example.com/cmd/tool" {
@@ -200,11 +211,11 @@ func TestModInfoDataRoundTrip(t *testing.T) {
 
 	got := make([]string, 0, len(info.Deps))
 	for _, dep := range info.Deps {
-		got = append(got, dep.Path+"@"+dep.Version)
+		got = append(got, dep.Path+"@"+dep.Version+";"+dep.Sum)
 	}
 	want := []string{
-		"github.com/google/go-cmp@v0.6.0",
-		"golang.org/x/sync@v0.8.0",
+		"github.com/google/go-cmp@v0.6.0;h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=",
+		"golang.org/x/sync@v0.8.0;h1:3NFvSEYkUoMifnESzZl15y791HH1qU2xm6eCJU5ZPXQ=",
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got deps %v; want %v", got, want)

--- a/tests/core/go_binary/buildinfo_test.go
+++ b/tests/core/go_binary/buildinfo_test.go
@@ -139,6 +139,7 @@ import (
 type dep struct {
     Path    string ` + "`json:\"path\"`" + `
     Version string ` + "`json:\"version\"`" + `
+    Sum     string ` + "`json:\"sum\"`" + `
 }
 
 type output struct {
@@ -169,7 +170,7 @@ func main() {
         out.MainVersion = info.Main.Version
         out.Settings = buildSettings(info)
         for _, module := range info.Deps {
-            out.Deps = append(out.Deps, dep{Path: module.Path, Version: module.Version})
+            out.Deps = append(out.Deps, dep{Path: module.Path, Version: module.Version, Sum: module.Sum})
         }
     }
     _ = json.NewEncoder(os.Stdout).Encode(out)
@@ -348,7 +349,7 @@ load("@package_metadata//rules:package_metadata.bzl", "package_metadata")
 
 package_metadata(
     name = "package_metadata",
-    purl = "pkg:golang/github.com/google/go-cmp@v0.6.0",
+    purl = "pkg:golang/github.com/google/go-cmp@v0.6.0?checksum=h1:ofyhxvXcZhMsU5ulbFiLKl%2FXBFqE1GSq7atu8tAmTRI%3D",
     visibility = ["//:__subpackages__"],
 )
 
@@ -434,6 +435,7 @@ local_path_override(
 type dep struct {
 	Path    string `json:"path"`
 	Version string `json:"version"`
+	Sum     string `json:"sum"`
 }
 
 type withDepOutput struct {
@@ -496,9 +498,16 @@ func TestReadBuildInfoDeps(t *testing.T) {
 	for _, dep := range got.Deps {
 		if dep.Path == "github.com/google/go-cmp" && dep.Version == "v0.6.0" {
 			foundCmp = true
+			wantSum := "h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI="
+			if dep.Sum != wantSum {
+				t.Fatalf("got go-cmp Sum %q; want %q", dep.Sum, wantSum)
+			}
 		}
 		if dep.Path == "example.com/versionless" && dep.Version == "(devel)" {
 			foundUnusedDeclaredDep = true
+			if dep.Sum != "" {
+				t.Fatalf("got versionless Sum %q; want empty", dep.Sum)
+			}
 		}
 	}
 	if !foundCmp {


### PR DESCRIPTION
**What type of PR is this?**

Feature

**What does this PR do? Why is it needed?**

`moduleFromPURL` discards everything from the first '?' or '#' onward, so a checksum qualifier on a `pkg:golang/...` PURL gets silently dropped.

bazel-contrib/bazel-gazelle#2409 is meant to add such a qualifier to the PURLs it generates for `go_repository`, carrying the module's go.sum `h1:` checksum.

Parse qualifiers as a URL query string, extract checksum, and set it on the resulting `Module`'s `Sum` field, so a binary linked with this metadata exposes the same checksum through `ReadBuildInfo()` that `go build` already sets for its own binaries.

Qualifier values are percent-decoded via `ParseQuery`, consistent with how the module path and version are already percent-decoded.

`buildInfoDeps`'s dedup key and sort comparator both now include `sum`, so 2 independently-authored `packageMetadata` files that disagree on the checksum for the same path and version are kept as distinct entries, rather than silently merged, matching the existing handling for other conflicting metadata.

**Which issues(s) does this PR fix?**

Fixes #4699.

**Other notes for review**

This would not have been possible without #4595, thanks to @sluongng!