### PR TITLE
Add missing bsd platform constraints

### DIFF
--- a/go/private/platforms.bzl
+++ b/go/private/platforms.bzl
@@ -22,6 +22,8 @@ BAZEL_GOOS_CONSTRAINTS = {
     "freebsd": "@platforms//os:freebsd",
     "ios": "@platforms//os:ios",
     "linux": "@platforms//os:linux",
+    "netbsd": "@platforms//os:netbsd",
+    "openbsd": "@platforms//os:openbsd",
     "qnx": "@platforms//os:qnx",
     "windows": "@platforms//os:windows",
 }


### PR DESCRIPTION
These are already handled in other lookup tables but were missing here
