### PR TITLE
Reset request_nogo to its default value in the stdlib transition

### DIFF
--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -50,10 +50,6 @@ load(
     "emit_preprofile",
 )
 load(
-    "//go/private/rules:transition.bzl",
-    "non_request_nogo_transition",
-)
-load(
     ":common.bzl",
     "COVERAGE_OPTIONS_DENYLIST",
     "GO_TOOLCHAIN",
@@ -822,7 +818,7 @@ def _go_context_data_impl(ctx):
 
     return [
         GoContextInfo(
-            coverdata = ctx.attr.coverdata[0][GoArchive],
+            coverdata = ctx.attr.coverdata[GoArchive],
         ),
         ctx.attr.stdlib[GoStdLib],
         ctx.attr.go_config[GoConfigInfo],
@@ -833,7 +829,6 @@ go_context_data = rule(
     attrs = {
         "coverdata": attr.label(
             mandatory = True,
-            cfg = non_request_nogo_transition,
             providers = [GoArchive],
         ),
         "go_config": attr.label(
@@ -843,9 +838,6 @@ go_context_data = rule(
         "stdlib": attr.label(
             mandatory = True,
             providers = [GoStdLib],
-        ),
-        "_allowlist_function_transition": attr.label(
-            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
         ),
     },
     doc = """go_context_data gathers information about the build configuration.

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -261,7 +261,11 @@ def _non_go_tool_transition_impl(settings, _attr):
     targets or protoc directly.
     """
     settings = dict(settings, **_reset_transition_dict)
+
+    # Non-Go tools don't run nogo, so use the default values rather than the
+    # tool values to share the configuration of plain exec tools.
     settings["//go/private:bootstrap_nogo"] = False
+    settings["//go/private:request_nogo"] = True
     return settings
 
 non_go_tool_transition = transition(

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -283,7 +283,12 @@ def _go_stdlib_transition_impl(settings, _attr):
         if label not in _stdlib_keep_keys:
             settings[label] = value
     settings["//go/config:tags"] = [t for t in settings["//go/config:tags"] if t in _TAG_AFFECTS_STDLIB]
+
+    # The standard library doesn't run nogo, so use the default values rather
+    # than the tool values to share the configuration of both regular targets
+    # and plain exec tools.
     settings["//go/private:bootstrap_nogo"] = False
+    settings["//go/private:request_nogo"] = True
     settings["//command_line_option:collect_code_coverage"] = False
     return settings
 

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -179,20 +179,6 @@ go_transition = transition(
     ] + TRANSITIONED_GO_SETTING_KEYS + _SETTING_KEY_TO_ORIGINAL_SETTING_KEY.values(),
 )
 
-def _non_request_nogo_transition(_settings, _attr):
-    # This transition is used to make sure we only end up with 1 copy of coverdata,
-    # even if a test links against it and is run in coverage mode.
-    #
-    # It is also used to make sure that we do not end up with multiple configurations
-    # for CC toolchain dependencies when doing CGO.
-    return {"//go/private:request_nogo": False}
-
-non_request_nogo_transition = transition(
-    implementation = _non_request_nogo_transition,
-    inputs = [],
-    outputs = ["//go/private:request_nogo"],
-)
-
 _common_reset_transition_dict = dict({
     "//go/private:request_nogo": False,
     "//go/config:static": False,

--- a/tests/core/starlark/cgo/cgo_test.bzl
+++ b/tests/core/starlark/cgo/cgo_test.bzl
@@ -183,7 +183,6 @@ def cgo_test_suite():
 
     runtime_lib_inputs_test(
         name = "static_runtime_lib_inputs_test",
-        expected_input_count = 2,
         expected_inputs = ["configured_dummy.a"],
         expected_linkopts = ["configured_dummy.a"],
         target_under_test = ":runtime_libs_static_binary",

--- a/tests/core/transition/tool_settings_test.go
+++ b/tests/core/transition/tool_settings_test.go
@@ -418,9 +418,7 @@ func TestStdlibSharesConfigurationWithExecTools(t *testing.T) {
 // built for the exec configuration is built in one of exactly three
 // configurations: the target configuration, the exec configuration and the
 // configuration of nogo, which differs from the exec configuration only in the
-// settings that keep nogo from analyzing its own dependencies. Any other
-// configuration is a fork introduced by a rules_go transition and causes every
-// target in it, including the C++ toolchain, to be analyzed and built again.
+// settings that keep nogo from analyzing its own dependencies.
 func TestNoConfigurationForksByDefault(t *testing.T) {
 	targetHashes := configHashes(t, "config(//:plain, target)")
 	if len(targetHashes) != 1 {

--- a/tests/core/transition/tool_settings_test.go
+++ b/tests/core/transition/tool_settings_test.go
@@ -281,16 +281,13 @@ func getGoOptions(t *testing.T, hashes ...string) []string {
 	if err := json.Unmarshal(bytes.TrimSpace(out), &jsonOut); err != nil {
 		t.Fatalf("Failed to decode bazel config JSON output %v: %q", err, string(out))
 	}
-	// The repository part of the keys depends on the canonical repository name,
-	// so only keep the part that identifies the setting.
-	const configPkg = "//go/config:"
 	var goOptions []string
 	for _, fragment := range jsonOut.Fragments {
 		if fragment.Name != "user-defined" {
 			continue
 		}
 		for key, value := range fragment.Options {
-			if _, name, found := strings.Cut(key, configPkg); found {
+			if name, ok := goOptionName(key); ok {
 				goOptions = append(goOptions, fmt.Sprintf("%s=%s", name, value))
 			}
 		}
@@ -300,11 +297,85 @@ func getGoOptions(t *testing.T, hashes ...string) []string {
 			continue
 		}
 		for key, diff := range fragment.OptionsDiff {
-			if _, name, found := strings.Cut(key, configPkg); found {
+			if name, ok := goOptionName(key); ok {
 				goOptions = append(goOptions, fmt.Sprintf("%s=%s vs %s", name, diff.First, diff.Second))
 			}
 		}
 	}
 	sort.Strings(goOptions)
 	return goOptions
+}
+
+// goOptionName returns the part of a rules_go setting's label that identifies
+// it. The repository part depends on the canonical repository name and is
+// dropped. Settings in //go/private are reported with a "private:" prefix.
+func goOptionName(key string) (string, bool) {
+	if _, name, found := strings.Cut(key, "//go/config:"); found {
+		return name, true
+	}
+	if _, name, found := strings.Cut(key, "//go/private:"); found {
+		return "private:" + name, true
+	}
+	return "", false
+}
+
+// TestStdlibSharesConfigurationWithTarget verifies that the standard library
+// a Go binary links against is built in the binary's own configuration when
+// nothing but default settings are in effect.
+func TestStdlibSharesConfigurationWithTarget(t *testing.T) {
+	// Restrict to the target configuration: the server may also hold //:plain
+	// in the exec configuration from an earlier test.
+	targetHashes := configHashes(t, "config(//:plain, target)")
+	if len(targetHashes) != 1 {
+		t.Fatalf("expected //:plain to be built in exactly one configuration, got %d", len(targetHashes))
+	}
+	stdlibHashes := configHashes(t, "deps(//:plain) intersect @io_bazel_rules_go//:stdlib")
+	if contains(stdlibHashes, targetHashes[0]) {
+		return
+	}
+	var diffs []string
+	for _, hash := range stdlibHashes {
+		diffs = append(diffs, strings.Join(getGoOptions(t, targetHashes[0], hash), ", "))
+	}
+	t.Errorf("no stdlib is built in the configuration of //:plain, the stdlib configurations differ from it in: %s",
+		strings.Join(diffs, "; "))
+}
+
+// TestStdlibSharesConfigurationWithExecTools verifies the same for the exec
+// configuration: every standard library reachable from a genrule tool,
+// including the one nogo is built against, is built in the configuration of
+// the tool itself.
+func TestStdlibSharesConfigurationWithExecTools(t *testing.T) {
+	toolHashes := configHashes(t, "deps(//:tool_user) intersect //:plain")
+	if len(toolHashes) != 1 {
+		t.Fatalf("expected //:tool_user to depend on //:plain in exactly one configuration, got %d", len(toolHashes))
+	}
+	stdlibHashes := configHashes(t, "deps(//:tool_user) intersect @io_bazel_rules_go//:stdlib")
+	var diffs []string
+	for _, hash := range stdlibHashes {
+		if hash != toolHashes[0] {
+			diffs = append(diffs, strings.Join(getGoOptions(t, toolHashes[0], hash), ", "))
+		}
+	}
+	if len(diffs) != 0 {
+		t.Errorf("a stdlib reachable from //:tool_user is not built in the configuration of //:plain, differing in: %s",
+			strings.Join(diffs, "; "))
+	}
+}
+
+// configHashes returns the hashes of the configurations of the targets matched
+// by the given cquery expression.
+func configHashes(t *testing.T, query string, flags ...string) []string {
+	// See nogoGoOptions for why the build is necessary.
+	if err := bazel_testing.RunBazel(append([]string{"build", "//:plain", "--nobuild"}, flags...)...); err != nil {
+		t.Fatalf("bazel build //:plain: %v", err)
+	}
+	out, err := bazel_testing.BazelOutput(append(
+		[]string{"cquery", "--output=jsonproto", query},
+		flags...,
+	)...)
+	if err != nil {
+		t.Fatalf("bazel cquery '%s': %v", query, err)
+	}
+	return extractConfigHashes(t, bytes.TrimSpace(out))
 }

--- a/tests/core/transition/tool_settings_test.go
+++ b/tests/core/transition/tool_settings_test.go
@@ -240,22 +240,72 @@ func contains(haystack []string, needle string) bool {
 	return false
 }
 
+// nullConfig is the checksum cquery reports for targets that aren't built in
+// any configuration, such as source files.
+const nullConfig = "null"
+
+type configuredTarget struct {
+	label string
+	hash  string
+}
+
+// cqueryResult holds the configured targets matched by a cquery expression in
+// the order Bazel reports them, which lists a target before its dependencies.
+type cqueryResult struct {
+	targets []configuredTarget
+	// isTool records which configurations are exec configurations. It is
+	// empty on Bazel versions that don't report configurations separately.
+	isTool map[string]bool
+}
+
 func extractConfigHashes(t *testing.T, rawJSONOut []byte) []string {
+	var hashes []string
+	for _, ct := range parseCqueryResult(t, rawJSONOut).targets {
+		hashes = append(hashes, ct.hash)
+	}
+	return hashes
+}
+
+func parseCqueryResult(t *testing.T, rawJSONOut []byte) cqueryResult {
+	type named struct {
+		Name string `json:"name"`
+	}
 	var jsonOut struct {
 		Results []struct {
+			Target struct {
+				Type          string `json:"type"`
+				Rule          *named `json:"rule"`
+				SourceFile    *named `json:"sourceFile"`
+				GeneratedFile *named `json:"generatedFile"`
+				PackageGroup  *named `json:"packageGroup"`
+			} `json:"target"`
 			Configuration struct {
 				Checksum string `json:"checksum"`
 			} `json:"configuration"`
 		} `json:"results"`
+		Configurations []struct {
+			Checksum string `json:"checksum"`
+			IsTool   bool   `json:"isTool"`
+		} `json:"configurations"`
 	}
 	if err := json.Unmarshal(rawJSONOut, &jsonOut); err != nil {
 		t.Fatalf("Failed to decode bazel cquery JSON output %v: %q", err, string(rawJSONOut))
 	}
-	var hashes []string
-	for _, result := range jsonOut.Results {
-		hashes = append(hashes, result.Configuration.Checksum)
+	result := cqueryResult{isTool: make(map[string]bool)}
+	for _, r := range jsonOut.Results {
+		label := fmt.Sprintf("<%s>", r.Target.Type)
+		for _, n := range []*named{r.Target.Rule, r.Target.SourceFile, r.Target.GeneratedFile, r.Target.PackageGroup} {
+			if n != nil {
+				label = n.Name
+				break
+			}
+		}
+		result.targets = append(result.targets, configuredTarget{label: label, hash: r.Configuration.Checksum})
 	}
-	return hashes
+	for _, c := range jsonOut.Configurations {
+		result.isTool[c.Checksum] = c.IsTool
+	}
+	return result
 }
 
 func getGoOptions(t *testing.T, hashes ...string) []string {
@@ -363,9 +413,78 @@ func TestStdlibSharesConfigurationWithExecTools(t *testing.T) {
 	}
 }
 
+// TestNoConfigurationForksByDefault verifies that, with nothing but default
+// settings in effect, every target reachable from a Go binary or from a tool
+// built for the exec configuration is built in one of exactly three
+// configurations: the target configuration, the exec configuration and the
+// configuration of nogo, which differs from the exec configuration only in the
+// settings that keep nogo from analyzing its own dependencies. Any other
+// configuration is a fork introduced by a rules_go transition and causes every
+// target in it, including the C++ toolchain, to be analyzed and built again.
+func TestNoConfigurationForksByDefault(t *testing.T) {
+	targetHashes := configHashes(t, "config(//:plain, target)")
+	if len(targetHashes) != 1 {
+		t.Fatalf("expected //:plain to be built in exactly one target configuration, got %d", len(targetHashes))
+	}
+	execHashes := configHashes(t, "deps(//:tool_user) intersect //:plain")
+	if len(execHashes) != 1 {
+		t.Fatalf("expected //:tool_user to depend on //:plain in exactly one configuration, got %d", len(execHashes))
+	}
+	nogoHashes := configHashes(t, "deps(//:plain) intersect //:my_nogo_actual")
+	if len(nogoHashes) != 1 {
+		t.Fatalf("expected //:plain to depend on //:my_nogo_actual in exactly one configuration, got %d", len(nogoHashes))
+	}
+	target, exec := targetHashes[0], execHashes[0]
+	expected := map[string]bool{target: true, exec: true, nogoHashes[0]: true, nullConfig: true}
+	// Bazel analyzes constraint values and other targets that don't read any
+	// configuration in a configuration of their own.
+	for _, hash := range configHashes(t, "kind(constraint_value, deps(//:plain))") {
+		expected[hash] = true
+	}
+
+	result := cqueryConfiguredTargets(t, "deps(//:plain + //:tool_user)")
+	var unexpected []string
+	labels := make(map[string][]string)
+	for _, ct := range result.targets {
+		if expected[ct.hash] {
+			continue
+		}
+		if _, seen := labels[ct.hash]; !seen {
+			unexpected = append(unexpected, ct.hash)
+		}
+		labels[ct.hash] = append(labels[ct.hash], ct.label)
+	}
+	for _, hash := range unexpected {
+		baseline, baselineName := target, "target"
+		if result.isTool[hash] {
+			baseline, baselineName = exec, "exec"
+		}
+		diff := strings.Join(getGoOptions(t, baseline, hash), ", ")
+		if diff == "" {
+			diff = "options other than rules_go settings"
+		}
+		examples, more := labels[hash], ""
+		if len(examples) > 5 {
+			examples, more = examples[:5], fmt.Sprintf(" and %d more", len(examples)-5)
+		}
+		t.Errorf("%d targets are built in a configuration that differs from the %s configuration in %s: %s%s",
+			len(labels[hash]), baselineName, diff, strings.Join(examples, ", "), more)
+	}
+}
+
 // configHashes returns the hashes of the configurations of the targets matched
 // by the given cquery expression.
 func configHashes(t *testing.T, query string, flags ...string) []string {
+	var hashes []string
+	for _, ct := range cqueryConfiguredTargets(t, query, flags...).targets {
+		hashes = append(hashes, ct.hash)
+	}
+	return hashes
+}
+
+// cqueryConfiguredTargets returns the configured targets matched by the given
+// cquery expression.
+func cqueryConfiguredTargets(t *testing.T, query string, flags ...string) cqueryResult {
 	// See nogoGoOptions for why the build is necessary.
 	if err := bazel_testing.RunBazel(append([]string{"build", "//:plain", "--nobuild"}, flags...)...); err != nil {
 		t.Fatalf("bazel build //:plain: %v", err)
@@ -377,5 +496,5 @@ func configHashes(t *testing.T, query string, flags ...string) []string {
 	if err != nil {
 		t.Fatalf("bazel cquery '%s': %v", query, err)
 	}
-	return extractConfigHashes(t, bytes.TrimSpace(out))
+	return parseCqueryResult(t, bytes.TrimSpace(out))
 }


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

`go_stdlib_transition` resets `//go/private:request_nogo` to `False` along with the other tool settings. The standard library never runs nogo, though, so the only effect of that reset is to move `@io_bazel_rules_go//:stdlib` into a configuration of its own: neither the configuration of a target built with default settings (e.g. a plain `bazel build //some:go_binary`) nor that of a tool built via a plain exec transition (e.g. a genrule tool) has the setting set.

That separate configuration isn't free: every Go rule resolves the C++ toolchain, so the toolchain and everything it depends on are analyzed and, for toolchains that build runtimes from source, built once more. Since `GoStdlib` takes the toolchain files as inputs, that duplicate build also sits in front of every Go compilation on the critical path of a cold build. In a build of BuildBuddy's executor on macOS with a hermetic LLVM toolchain, this is a second from-source build of compiler-rt (281 C compiles) on both the target and the exec side.

This resets the setting to its default value (`True`) instead of the tool value. With that, the stdlib of a target built with default settings shares the target's configuration, and the stdlib of nogo (whose own configuration has `request_nogo = False`) shares the configuration of plain exec tools rather than keeping one of its own. There is no cycle risk: the stdlib rule only depends on `//:go_config` and the toolchains, none of which reach nogo.

The same reasoning applies to two more places that set `request_nogo = False` for targets that never run nogo, and the follow-up commits fix those too so that a default build has no configuration forks left at all:

* `non_go_tool_transition` inherited the value from the dict it shares with `go_tool_transition`, which gave the builder, pack, the legacy protoc toolchain and every `proto_library` a `go_proto_library` depends on a configuration of their own.
* `go_context_data` transitioned its `coverdata` dependency, a `go_tool_library`, which moved coverdata, the C++ toolchain it resolves and the Go SDK targets of its toolchain into a configuration of their own, once on the target and once on the exec side. The transition dates back to #4016 and was also relied on by `cgo_context_data` (#4512), which has since been removed (#4599).

**Which issues(s) does this PR fix?**

None filed.

**Other notes for review**

* Two tests for the stdlib, one per claim. On #4704 alone they fail with `no stdlib is built in the configuration of //:plain, the stdlib configurations differ from it in: private:request_nogo=null vs false` and `a stdlib reachable from //:tool_user is not built in the configuration of //:plain, differing in: private:request_nogo=null vs false`.
* A new test verifies the general property: every target reachable from a Go binary or from a genrule tool is built in the target configuration, the exec configuration or the configuration of nogo. On the first commit alone it fails with `121 targets are built in a configuration that differs from the exec configuration in private:request_nogo=null vs false: @io_bazel_rules_go//go/tools/coverdata:coverdata, @go_sdk//:pack.exe, @go_sdk//:builder, ...` and the corresponding message for the target configuration.
* `static_runtime_lib_inputs_test` expected the C++ runtime archive twice among the link inputs, once per configuration of the binary and its stdlib. With both in one configuration there is a single copy, which is what the test asserts now; `stdlib_runtime_lib_inputs_test` still covers the two-configuration case via a tag the stdlib transition drops.
* The test helper that reports differing settings now also covers `//go/private` settings (prefixed with `private:`), since that is the package the difference lives in.
