### PR TITLE
Apply the static attribute at link time instead of via a transition

### DIFF
--- a/docs/go/core/rules.md
+++ b/docs/go/core/rules.md
@@ -300,8 +300,8 @@ intermediate rule that allows users to apply these transitions.
 
 The '//go/config:static' and '//go/config:pure' settings are an exception: they are
 inherited from the value set on the command line, as they determine whether the tool
-can run on the execution platform. The 'static' and 'pure' attributes of an enclosing
-rule are still reset.
+can run on the execution platform. The 'pure' attribute of an enclosing rule is still
+reset.
 
 **ATTRIBUTES**
 

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -88,7 +88,7 @@ def emit_link(
     else:
         extld = extld_from_cc_toolchain(go)
         tool_args.add_all(extld)
-        if extld and (go.mode.static or
+        if extld and (go.static_link or
                       go.mode.race or
                       go.mode.linkmode != LINKMODE_NORMAL or
                       go.mode.goos == "windows" and go.mode.msan):
@@ -108,7 +108,7 @@ def emit_link(
             #       runtime/cgo(.text): relocation target memset not defined
             tool_args.add("-linkmode", "external")
 
-    if go.mode.static:
+    if go.static_link:
         extldflags.append("-static")
     if go.mode.linkmode != LINKMODE_NORMAL:
         builder_args.add("-buildmode", go.mode.linkmode)

--- a/go/private/context.bzl
+++ b/go/private/context.bzl
@@ -600,7 +600,8 @@ def go_context(
         go_context_data = None,
         maybe_needs_cc_toolchain = True,
         goos = "auto",
-        goarch = "auto"):
+        goarch = "auto",
+        static = "auto"):
     """Returns an API used to build Go code.
 
     See /go/toolchains.rst#go-context
@@ -661,6 +662,15 @@ def go_context(
             mode_kwargs["pure"] = True
         mode = GoConfigInfo(**mode_kwargs)
         validate_mode(mode)
+
+    if static not in ("on", "off", "auto"):
+        fail('static: must be "on", "off", or "auto", got "{}"'.format(static))
+
+    # Static linking only affects the link action of the rule it is set on, so
+    # the static attribute is applied here rather than through a configuration
+    # transition, which would give every dependency a configuration of its own.
+    # It is kept out of mode since that describes how archives are compiled.
+    static_link = mode.static if static == "auto" else static == "on"
 
     if stdlib:
         goroot = stdlib.root_file.dirname
@@ -761,6 +771,7 @@ def go_context(
         toolchain = toolchain,
         sdk = toolchain.sdk,
         mode = mode,
+        static_link = static_link,
         stdlib = stdlib,
         actions = ctx.actions,
         cc_toolchain_files = cc_toolchain_files,

--- a/go/private/rules/binary.bzl
+++ b/go/private/rules/binary.bzl
@@ -132,6 +132,7 @@ def _go_binary_impl(ctx):
         maybe_needs_cc_toolchain = maybe_needs_cc_toolchain(ctx.attr, go_infos = ctx.attr.deps),
         goos = ctx.attr.goos,
         goarch = ctx.attr.goarch,
+        static = ctx.attr.static,
     )
 
     generated_srcs = []

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -68,6 +68,7 @@ def _go_test_impl(ctx):
         maybe_needs_cc_toolchain = maybe_needs_cc_toolchain(ctx.attr, go_infos = ctx.attr.deps),
         goos = ctx.attr.goos,
         goarch = ctx.attr.goarch,
+        static = ctx.attr.static,
     )
 
     validation_outputs = []

--- a/go/private/rules/transition.bzl
+++ b/go/private/rules/transition.bzl
@@ -36,7 +36,6 @@ load(
 # Keep their package name in sync with the implementation of
 # _original_setting_key.
 TRANSITIONED_GO_SETTING_KEYS = [
-    "//go/config:static",
     "//go/config:msan",
     "//go/config:race",
     "//go/config:pure",
@@ -70,9 +69,11 @@ TOOL_INHERITED_SETTING_KEYS = [
 
 def _setting_before_go_transition(settings, key):
     """Returns the value of key from before the last go_transition."""
-    original_value = settings[_SETTING_KEY_TO_ORIGINAL_SETTING_KEY[key]]
-    if original_value:
-        return json.decode(original_value)
+    original_key = _SETTING_KEY_TO_ORIGINAL_SETTING_KEY.get(key)
+    if original_key:
+        original_value = settings[original_key]
+        if original_value:
+            return json.decode(original_value)
     return settings[key]
 
 def _go_transition_impl(settings, attr):
@@ -87,7 +88,9 @@ def _go_transition_impl(settings, attr):
     original_settings = settings
     settings = dict(settings)
 
-    _set_ternary(settings, attr, "static")
+    # The static attribute is deliberately not applied here: it only affects
+    # the link action of the rule it is set on and is thus read directly by
+    # go_context rather than propagated to all dependencies as a setting.
     race = _set_ternary(settings, attr, "race")
     msan = _set_ternary(settings, attr, "msan")
     pure = _set_ternary(settings, attr, "pure")
@@ -354,8 +357,8 @@ intermediate rule that allows users to apply these transitions.
 
 The '//go/config:static' and '//go/config:pure' settings are an exception: they are
 inherited from the value set on the command line, as they determine whether the tool
-can run on the execution platform. The 'static' and 'pure' attributes of an enclosing
-rule are still reset.
+can run on the execution platform. The 'pure' attribute of an enclosing rule is still
+reset.
 """,
 )
 

--- a/go/toolchains.rst
+++ b/go/toolchains.rst
@@ -674,6 +674,12 @@ Fields
 | Controls the compilation setup affecting things like enabling profilers and sanitizers.          |
 | See `compilation modes`_ for more information about the allowed values.                          |
 +--------------------------------+-----------------------------------------------------------------+
+| :param:`static_link`           | :type:`bool`                                                    |
++--------------------------------+-----------------------------------------------------------------+
+| Whether binaries linked through this context are statically linked. This is the value of the     |
+| ``static`` mode after applying the ``static`` attribute of the rule, which only affects linking  |
+| and thus isn't part of :param:`mode`.                                                            |
++--------------------------------+-----------------------------------------------------------------+
 | :param:`stdlib`                | :type:`GoStdLib`                                                |
 +--------------------------------+-----------------------------------------------------------------+
 | The standard library and tools to use in this build mode. This may be the                        |

--- a/tests/core/transition/tool_settings_test.go
+++ b/tests/core/transition/tool_settings_test.go
@@ -122,6 +122,33 @@ func TestCommandLineSettingsReachToolsWithExcludedStarlarkFlags(t *testing.T) {
 	}
 }
 
+// TestStaticAttributeDoesNotReachDependencies verifies that the static
+// attribute only affects the link action of the binary it is set on. Static
+// linking is a property of that single link, so applying it through the
+// configuration would recompile every dependency for no reason.
+func TestStaticAttributeDoesNotReachDependencies(t *testing.T) {
+	if err := bazel_testing.RunBazel("build", "//:plain", "//:static_attr", "--nobuild"); err != nil {
+		t.Fatalf("bazel build //:plain //:static_attr: %v", err)
+	}
+	hashes := make(map[string][]string)
+	for _, target := range []string{"//:plain", "//:static_attr"} {
+		query := fmt.Sprintf("deps(%s) intersect //:lib", target)
+		out, err := bazel_testing.BazelOutput("cquery", "--output=jsonproto", query)
+		if err != nil {
+			t.Fatalf("bazel cquery '%s': %v", query, err)
+		}
+		hashes[target] = extractConfigHashes(t, bytes.TrimSpace(out))
+		if len(hashes[target]) != 1 {
+			t.Fatalf("expected %s to depend on //:lib in exactly one configuration, got %d", target, len(hashes[target]))
+		}
+	}
+	plain, static := hashes["//:plain"][0], hashes["//:static_attr"][0]
+	if plain != static {
+		t.Errorf("//:lib is built in different configurations for //:plain and //:static_attr, differing in: %s",
+			strings.Join(getGoOptions(t, plain, static), ", "))
+	}
+}
+
 // TestRuleAttributesDoNotReachTools verifies that the static and pure
 // attributes of an individual rule do not propagate to Go tool binaries, which
 // would build one copy of every tool per distinct attribute value.


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

The `static` attribute of `go_binary` and `go_test` only affects how the binary itself is linked (`-extldflags -static` and the choice of external linking in `emit_link`), but `go_transition` turned it into a setting that every dependency was configured with. Consequences:

* A binary with `static = "on"` compiled a private copy of all of its dependencies, plus nogo runs for all of them.
* Two binaries that only differed in this attribute landed in two configurations.
* The bookkeeping settings `//go/config:static` and `original_static` leaked into every non-Go dependency reached from such a configuration, including the C++ toolchain and its runtime deps.

This drops `static` from the transition and instead reads the attribute in `go_context`, which exposes the effective value as `go.static_link` (the attribute applied on top of the `//go/config:static` flag). `emit_link` uses that instead of `go.mode.static`. `mode` is deliberately left alone since it describes how archives are compiled, and the archive consistency check compares it across dependencies.

Command-line uses of `--@io_bazel_rules_go//go/config:static` are unaffected, and Go tool binaries keep inheriting that value (#4689).

**Which issues(s) does this PR fix?**


**Other notes for review**