### PR TITLE
link: report only actually-reachable deps in build info

### DIFF
--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -57,6 +57,10 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
 
     # store export information for compiling dependent packages separately
     out_export = go.declare_file(go, name = source.name, ext = pre_ext + ".x")
+
+    # store the packages actually imported for determining build-info reachability
+    out_imports = go.declare_file(go, name = source.name, ext = pre_ext + ".imports")
+
     out_cgo_export_h = None  # set if cgo used in c-shared or c-archive mode
 
     nogo = go.nogo
@@ -126,6 +130,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
             headers = headers,
             out_lib = out_lib,
             out_export = out_export,
+            out_imports = out_imports,
             out_facts = out_facts,
             out_diagnostics = out_diagnostics,
             out_nogo_validation = out_nogo_validation,
@@ -158,6 +163,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
             headers = headers,
             out_lib = out_lib,
             out_export = out_export,
+            out_imports = out_imports,
             out_facts = out_facts,
             out_diagnostics = out_diagnostics,
             out_nogo_validation = out_nogo_validation,
@@ -196,6 +202,7 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         _cxxopts = tuple(source.cxxopts),
         _clinkopts = tuple(source.clinkopts),
         _package_metadata = getattr(source, "_package_metadata", None),
+        _imports = out_imports,
 
         # Information on dependencies
         _dep_labels = tuple([d.data.label for d in direct]),
@@ -222,8 +229,16 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     cgo_exports = depset(direct = cgo_exports_direct, transitive = [a.cgo_exports for a in direct], order = "preorder")
     package_metadata = getattr(data, "_package_metadata", None)
     package_metadata_files = depset(
-        direct = [package_metadata] if package_metadata else [],
+        direct = [data] if package_metadata else [],
         transitive = [getattr(a, "_package_metadata_files", depset()) for a in direct],
+    )
+    imports_files = depset(
+        direct = [data],
+        transitive = [getattr(a, "_imports_files", depset()) for a in direct],
+    )
+    buildinfo_link_inputs = depset(
+        direct = ([package_metadata] if package_metadata else []) + [out_imports],
+        transitive = [getattr(a, "_buildinfo_link_inputs", depset()) for a in direct],
     )
     return GoArchive(
         source = source,
@@ -238,4 +253,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         runfiles = runfiles,
         _headers = headers,
         _package_metadata_files = package_metadata_files,
+        _imports_files = imports_files,
+        _buildinfo_link_inputs = buildinfo_link_inputs,
     )

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -227,6 +227,11 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     # to the archive only exposes a single header rather than combining all headers.
     cgo_exports_direct = [out_cgo_export_h] if out_cgo_export_h else []
     cgo_exports = depset(direct = cgo_exports_direct, transitive = [a.cgo_exports for a in direct], order = "preorder")
+    package_metadata = getattr(data, "_package_metadata", None)
+    buildinfo_link_inputs = depset(
+        direct = ([package_metadata] if package_metadata else []) + [data._imports],
+        transitive = [getattr(a, "_buildinfo_link_inputs", depset()) for a in direct],
+    )
     return GoArchive(
         source = source,
         data = data,
@@ -239,4 +244,5 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         cgo_exports = cgo_exports,
         runfiles = runfiles,
         _headers = headers,
+        _buildinfo_link_inputs = buildinfo_link_inputs,
     )

--- a/go/private/actions/archive.bzl
+++ b/go/private/actions/archive.bzl
@@ -227,19 +227,6 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
     # to the archive only exposes a single header rather than combining all headers.
     cgo_exports_direct = [out_cgo_export_h] if out_cgo_export_h else []
     cgo_exports = depset(direct = cgo_exports_direct, transitive = [a.cgo_exports for a in direct], order = "preorder")
-    package_metadata = getattr(data, "_package_metadata", None)
-    package_metadata_files = depset(
-        direct = [data] if package_metadata else [],
-        transitive = [getattr(a, "_package_metadata_files", depset()) for a in direct],
-    )
-    imports_files = depset(
-        direct = [data],
-        transitive = [getattr(a, "_imports_files", depset()) for a in direct],
-    )
-    buildinfo_link_inputs = depset(
-        direct = ([package_metadata] if package_metadata else []) + [out_imports],
-        transitive = [getattr(a, "_buildinfo_link_inputs", depset()) for a in direct],
-    )
     return GoArchive(
         source = source,
         data = data,
@@ -252,7 +239,4 @@ def emit_archive(go, source = None, _recompile_suffix = "", recompile_internal_d
         cgo_exports = cgo_exports,
         runfiles = runfiles,
         _headers = headers,
-        _package_metadata_files = package_metadata_files,
-        _imports_files = imports_files,
-        _buildinfo_link_inputs = buildinfo_link_inputs,
     )

--- a/go/private/actions/compilepkg.bzl
+++ b/go/private/actions/compilepkg.bzl
@@ -69,6 +69,7 @@ def emit_compilepkg(
         ldflags = None,
         out_lib = None,
         out_export = None,
+        out_imports = None,
         out_facts = None,
         out_diagnostics = None,
         out_nogo_validation = None,
@@ -83,6 +84,8 @@ def emit_compilepkg(
         fail("sources is a required parameter")
     if out_lib == None:
         fail("out_lib is a required parameter")
+    if out_imports == None:
+        fail("out_imports is a required parameter")
 
     have_nogo = nogo != None and nogo.executable != None
     if have_nogo != (out_facts != None):
@@ -97,7 +100,7 @@ def emit_compilepkg(
     inputs_direct = (sources + embedsrcs + [sdk.package_list, go.toolchain._pack] +
                      [archive.data.export_file for archive in archives])
     inputs_transitive = [sdk.headers, sdk.tools, go.stdlib.libs, headers]
-    outputs = [out_lib, out_export]
+    outputs = [out_lib, out_export, out_imports]
 
     shared_args = go.builder_args(go)
     shared_args.add_all(sources, before_each = "-src")
@@ -140,6 +143,7 @@ def emit_compilepkg(
 
     compile_args.add("-lo", out_lib)
     compile_args.add("-o", out_export)
+    compile_args.add("-imports", out_imports)
     if out_cgo_export_h:
         compile_args.add("-cgoexport", out_cgo_export_h)
         outputs.append(out_cgo_export_h)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -37,6 +37,12 @@ load(
 def _format_archive(d):
     return "{}={}={}".format(d.label, d.importmap, d.file.path)
 
+def _format_package_metadata(d):
+    return "{}={}".format(d.importmap, d._package_metadata.path)
+
+def _format_imports(d):
+    return "{}={}".format(d.importmap, d._imports.path)
+
 def emit_link(
         go,
         archive = None,
@@ -134,17 +140,26 @@ def emit_link(
         arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct])
 
     package_metadata_files = depset(
+        direct = [d for d in test_archives if getattr(d, "_package_metadata", None)],
+        transitive = [getattr(d, "_package_metadata_files", depset()) for d in archive.direct],
+    )
+    imports_files = depset(
+        direct = test_archives,
+        transitive = [getattr(archive, "_imports_files", depset())],
+    )
+    buildinfo_link_inputs = depset(
         direct = [
             metadata
             for archive_data in test_archives
             for metadata in [getattr(archive_data, "_package_metadata", None)]
             if metadata
-        ],
-        transitive = [getattr(d, "_package_metadata_files", depset()) for d in archive.direct],
+        ] + [archive_data._imports for archive_data in test_archives],
+        transitive = [getattr(archive, "_buildinfo_link_inputs", depset())],
     )
 
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
-    builder_args.add_all(package_metadata_files, before_each = "-package_metadata")
+    builder_args.add_all(package_metadata_files, before_each = "-package_metadata", map_each = _format_package_metadata)
+    builder_args.add_all(imports_files, before_each = "-imports", map_each = _format_imports)
     builder_args.add("-package_list", go.sdk.package_list)
     if go.coverage_enabled:
         builder_args.add("-cover")
@@ -214,7 +229,7 @@ def emit_link(
         go.cc_toolchain_files,
         go.sdk.tools,
         go.stdlib.libs,
-        package_metadata_files,
+        buildinfo_link_inputs,
     ]
     inputs = depset(direct = inputs_direct, transitive = inputs_transitive)
 

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -42,8 +42,13 @@ def _format_package_metadata(d):
         return None
     return "{}={}".format(d.importmap, d._package_metadata.path)
 
-def _format_imports(d):
-    return "{}={}".format(d.importmap, d._imports.path)
+def _format_imports_except(main_archive_path):
+    def _format(d):
+        if d.file.path == main_archive_path:
+            return None
+        return "{}={}".format(d.importmap, d._imports.path)
+
+    return _format
 
 def emit_link(
         go,
@@ -142,15 +147,24 @@ def emit_link(
         arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct])
 
     all_archive_data = depset(test_archives, transitive = [archive.transitive])
-    all_archive_data_list = all_archive_data.to_list()
     buildinfo_link_inputs = depset(
-        [d._package_metadata for d in all_archive_data_list if d._package_metadata] +
-        [d._imports for d in all_archive_data_list],
+        direct = [
+            metadata
+            for archive_data in test_archives
+            for metadata in [getattr(archive_data, "_package_metadata", None)]
+            if metadata
+        ] + [archive_data._imports for archive_data in test_archives],
+        transitive = [getattr(archive, "_buildinfo_link_inputs", depset())],
     )
 
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
     builder_args.add_all(all_archive_data, before_each = "-package_metadata", map_each = _format_package_metadata)
-    builder_args.add_all(all_archive_data, before_each = "-imports", map_each = _format_imports)
+    builder_args.add_all(
+        all_archive_data,
+        before_each = "-imports",
+        map_each = _format_imports_except(main_archive_path = archive.data.file.path),
+        allow_closure = True,  # safe: the captured path is not a large analysis-phase object, but a string
+    )
     builder_args.add("-package_list", go.sdk.package_list)
     if go.coverage_enabled:
         builder_args.add("-cover")
@@ -195,6 +209,7 @@ def emit_link(
     builder_args.add("-o", executable)
     builder_args.add("-main", archive.data.file)
     builder_args.add("-main_package_path", buildinfo_main_package_path)
+    builder_args.add("-main_imports", archive.data._imports)
     if buildinfo_module_metadata:
         builder_args.add("-main_module_metadata", buildinfo_module_metadata)
     builder_args.add("-p", archive.data.importmap)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -38,6 +38,8 @@ def _format_archive(d):
     return "{}={}={}".format(d.label, d.importmap, d.file.path)
 
 def _format_package_metadata(d):
+    if not d._package_metadata:
+        return None
     return "{}={}".format(d.importmap, d._package_metadata.path)
 
 def _format_imports(d):
@@ -139,27 +141,16 @@ def emit_link(
     else:
         arcs = depset(test_archives, transitive = [d.transitive for d in archive.direct])
 
-    package_metadata_files = depset(
-        direct = [d for d in test_archives if getattr(d, "_package_metadata", None)],
-        transitive = [getattr(d, "_package_metadata_files", depset()) for d in archive.direct],
-    )
-    imports_files = depset(
-        direct = test_archives,
-        transitive = [getattr(archive, "_imports_files", depset())],
-    )
+    all_archive_data = depset(test_archives, transitive = [archive.transitive])
+    all_archive_data_list = all_archive_data.to_list()
     buildinfo_link_inputs = depset(
-        direct = [
-            metadata
-            for archive_data in test_archives
-            for metadata in [getattr(archive_data, "_package_metadata", None)]
-            if metadata
-        ] + [archive_data._imports for archive_data in test_archives],
-        transitive = [getattr(archive, "_buildinfo_link_inputs", depset())],
+        [d._package_metadata for d in all_archive_data_list if d._package_metadata] +
+        [d._imports for d in all_archive_data_list],
     )
 
     builder_args.add_all(arcs, before_each = "-arc", map_each = _format_archive)
-    builder_args.add_all(package_metadata_files, before_each = "-package_metadata", map_each = _format_package_metadata)
-    builder_args.add_all(imports_files, before_each = "-imports", map_each = _format_imports)
+    builder_args.add_all(all_archive_data, before_each = "-package_metadata", map_each = _format_package_metadata)
+    builder_args.add_all(all_archive_data, before_each = "-imports", map_each = _format_imports)
     builder_args.add("-package_list", go.sdk.package_list)
     if go.coverage_enabled:
         builder_args.add("-cover")

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -42,8 +42,8 @@ def _format_package_metadata(d):
         return None
     return "{}={}".format(d.importmap, d._package_metadata.path)
 
-def _format_imports(d, main_archive_path):
-    if d.file.path == main_archive_path:
+def _format_imports(d, main_archive_file):
+    if d.file == main_archive_file:
         return None
     return "{}={}".format(d.importmap, d._imports.path)
 
@@ -159,7 +159,7 @@ def emit_link(
     builder_args.add_all(
         all_archive_data,
         before_each = "-imports",
-        map_each = lambda d: _format_imports(d, archive.data.file.path),
+        map_each = lambda d: _format_imports(d, archive.data.file),
         allow_closure = True,
     )
     builder_args.add("-package_list", go.sdk.package_list)

--- a/go/private/actions/link.bzl
+++ b/go/private/actions/link.bzl
@@ -42,13 +42,10 @@ def _format_package_metadata(d):
         return None
     return "{}={}".format(d.importmap, d._package_metadata.path)
 
-def _format_imports_except(main_archive_path):
-    def _format(d):
-        if d.file.path == main_archive_path:
-            return None
-        return "{}={}".format(d.importmap, d._imports.path)
-
-    return _format
+def _format_imports(d, main_archive_path):
+    if d.file.path == main_archive_path:
+        return None
+    return "{}={}".format(d.importmap, d._imports.path)
 
 def emit_link(
         go,
@@ -162,8 +159,8 @@ def emit_link(
     builder_args.add_all(
         all_archive_data,
         before_each = "-imports",
-        map_each = _format_imports_except(main_archive_path = archive.data.file.path),
-        allow_closure = True,  # safe: the captured path is not a large analysis-phase object, but a string
+        map_each = lambda d: _format_imports(d, archive.data.file.path),
+        allow_closure = True,
     )
     builder_args.add("-package_list", go.sdk.package_list)
     if go.coverage_enabled:

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -763,8 +763,16 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
                 mode = go.mode,
                 _headers = internal_archive._headers,
                 _package_metadata_files = depset(
-                    direct = [package_metadata] if package_metadata else [],
+                    direct = [arc_data] if package_metadata else [],
                     transitive = [getattr(a, "_package_metadata_files", depset()) for a in deps],
+                ),
+                _imports_files = depset(
+                    direct = [arc_data],
+                    transitive = [getattr(a, "_imports_files", depset()) for a in deps],
+                ),
+                _buildinfo_link_inputs = depset(
+                    direct = ([package_metadata] if package_metadata else []) + [arc_data._imports],
+                    transitive = [getattr(a, "_buildinfo_link_inputs", depset()) for a in deps],
                 ),
             )
         label_to_archive[label] = archive

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -762,6 +762,10 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
                 runfiles = go_info.runfiles,
                 mode = go.mode,
                 _headers = internal_archive._headers,
+                _buildinfo_link_inputs = depset(
+                    direct = ([package_metadata] if package_metadata else []) + [arc_data._imports],
+                    transitive = [getattr(a, "_buildinfo_link_inputs", depset()) for a in deps],
+                ),
             )
         label_to_archive[label] = archive
 

--- a/go/private/rules/test.bzl
+++ b/go/private/rules/test.bzl
@@ -762,18 +762,6 @@ def _recompile_external_deps(go, external_go_info, internal_archive, library_lab
                 runfiles = go_info.runfiles,
                 mode = go.mode,
                 _headers = internal_archive._headers,
-                _package_metadata_files = depset(
-                    direct = [arc_data] if package_metadata else [],
-                    transitive = [getattr(a, "_package_metadata_files", depset()) for a in deps],
-                ),
-                _imports_files = depset(
-                    direct = [arc_data],
-                    transitive = [getattr(a, "_imports_files", depset()) for a in deps],
-                ),
-                _buildinfo_link_inputs = depset(
-                    direct = ([package_metadata] if package_metadata else []) + [arc_data._imports],
-                    transitive = [getattr(a, "_buildinfo_link_inputs", depset()) for a in deps],
-                ),
             )
         label_to_archive[label] = archive
 

--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -89,6 +89,67 @@ func validSemverIdentifiers(value string, rejectNumericLeadingZero bool) bool {
 	return true
 }
 
+func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []string) ([]moduleInfo, error) {
+	metadataPathByPackage, err := parseKeyedPaths(packageMetadataFiles)
+	if err != nil {
+		return nil, err
+	}
+	importsPathByPackage, err := parseKeyedPaths(importsFiles)
+	if err != nil {
+		return nil, err
+	}
+
+	importsByPackage := make(map[string][]string, len(importsPathByPackage))
+	for pkg, path := range importsPathByPackage {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading imports manifest %q: %w", path, err)
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				importsByPackage[pkg] = append(importsByPackage[pkg], line)
+			}
+		}
+	}
+
+	reachable := make(map[string]bool)
+	var queue []string
+	if mainPackage != "" {
+		queue = append(queue, mainPackage)
+	}
+	for len(queue) > 0 {
+		pkg := queue[len(queue)-1]
+		queue = queue[:len(queue)-1]
+		if reachable[pkg] {
+			continue
+		}
+		reachable[pkg] = true
+		queue = append(queue, importsByPackage[pkg]...)
+	}
+
+	var metadataPaths []string
+	for pkg := range reachable {
+		if path, ok := metadataPathByPackage[pkg]; ok {
+			metadataPaths = append(metadataPaths, path)
+		}
+	}
+	sort.Strings(metadataPaths)
+	return modulesFromPackageMetadataFiles(metadataPaths)
+}
+
+func parseKeyedPaths(entries []string) (map[string]string, error) {
+	result := make(map[string]string, len(entries))
+	for _, entry := range entries {
+		key, path, ok := strings.Cut(entry, "=")
+		if !ok {
+			return nil, fmt.Errorf("malformed key=path entry %q, expected \"key=path\"", entry)
+		}
+		result[key] = path
+	}
+	return result, nil
+}
+
 func modulesFromPackageMetadataFiles(paths []string) ([]moduleInfo, error) {
 	modules := make([]moduleInfo, 0, len(paths))
 	for _, path := range paths {

--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -99,20 +99,6 @@ func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []s
 		return nil, err
 	}
 
-	importsByPackage := make(map[string][]string, len(importsPathByPackage))
-	for pkg, path := range importsPathByPackage {
-		data, err := os.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("reading imports manifest %q: %w", path, err)
-		}
-		for _, line := range strings.Split(string(data), "\n") {
-			line = strings.TrimSpace(line)
-			if line != "" {
-				importsByPackage[pkg] = append(importsByPackage[pkg], line)
-			}
-		}
-	}
-
 	reachable := make(map[string]bool)
 	var queue []string
 	if mainPackage != "" {
@@ -125,7 +111,21 @@ func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []s
 			continue
 		}
 		reachable[pkg] = true
-		queue = append(queue, importsByPackage[pkg]...)
+
+		path, ok := importsPathByPackage[pkg]
+		if !ok {
+			continue
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("reading imports manifest %q: %w", path, err)
+		}
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line != "" {
+				queue = append(queue, line)
+			}
+		}
 	}
 
 	var metadataPaths []string

--- a/go/tools/builders/buildinfo.go
+++ b/go/tools/builders/buildinfo.go
@@ -89,7 +89,7 @@ func validSemverIdentifiers(value string, rejectNumericLeadingZero bool) bool {
 	return true
 }
 
-func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []string) ([]moduleInfo, error) {
+func reachableModules(mainImportsPath string, packageMetadataFiles, importsFiles []string) ([]moduleInfo, error) {
 	metadataPathByPackage, err := parseKeyedPaths(packageMetadataFiles)
 	if err != nil {
 		return nil, err
@@ -101,8 +101,11 @@ func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []s
 
 	reachable := make(map[string]bool)
 	var queue []string
-	if mainPackage != "" {
-		queue = append(queue, mainPackage)
+	if mainImportsPath != "" {
+		queue, err = readImportsManifest(mainImportsPath)
+		if err != nil {
+			return nil, err
+		}
 	}
 	for len(queue) > 0 {
 		pkg := queue[len(queue)-1]
@@ -116,16 +119,11 @@ func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []s
 		if !ok {
 			continue
 		}
-		data, err := os.ReadFile(path)
+		imports, err := readImportsManifest(path)
 		if err != nil {
-			return nil, fmt.Errorf("reading imports manifest %q: %w", path, err)
+			return nil, err
 		}
-		for _, line := range strings.Split(string(data), "\n") {
-			line = strings.TrimSpace(line)
-			if line != "" {
-				queue = append(queue, line)
-			}
-		}
+		queue = append(queue, imports...)
 	}
 
 	var metadataPaths []string
@@ -136,6 +134,21 @@ func reachableModules(mainPackage string, packageMetadataFiles, importsFiles []s
 	}
 	sort.Strings(metadataPaths)
 	return modulesFromPackageMetadataFiles(metadataPaths)
+}
+
+func readImportsManifest(path string) ([]string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading imports manifest %q: %w", path, err)
+	}
+	var imports []string
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			imports = append(imports, line)
+		}
+	}
+	return imports, nil
 }
 
 func parseKeyedPaths(entries []string) (map[string]string, error) {

--- a/go/tools/builders/compilepkg.go
+++ b/go/tools/builders/compilepkg.go
@@ -17,6 +17,7 @@
 package main
 
 import (
+	"bytes"
 	"crypto/sha256"
 	"errors"
 	"flag"
@@ -41,7 +42,7 @@ func compilePkg(args []string) error {
 	var unfilteredSrcs, coverSrcs, embedSrcs, embedLookupDirs, embedRoots, recompileInternalDeps multiFlag
 	var deps archiveMultiFlag
 	var importPath, packagePath, packageListPath, coverMode string
-	var outLinkobjPath, outInterfacePath, cgoExportHPath, cgoGoSrcsPath string
+	var outLinkobjPath, outInterfacePath, outImportsPath, cgoExportHPath, cgoGoSrcsPath string
 	var testFilter string
 	var gcFlags, asmFlags, cppFlags, cFlags, cxxFlags, objcFlags, objcxxFlags, ldFlags quoteMultiFlag
 	var coverFormat string
@@ -67,6 +68,7 @@ func compilePkg(args []string) error {
 	fs.StringVar(&coverMode, "cover_mode", "", "The coverage mode to use. Empty if coverage instrumentation should not be added.")
 	fs.StringVar(&outLinkobjPath, "lo", "", "The full output archive file required by the linker")
 	fs.StringVar(&outInterfacePath, "o", "", "The export-only output archive required to compile dependent packages")
+	fs.StringVar(&outImportsPath, "imports", "", "Path to write the packagePaths actually imported by the filtered sources, one per line.")
 	fs.StringVar(&cgoExportHPath, "cgoexport", "", "The _cgo_exports.h file to write")
 	fs.StringVar(&cgoGoSrcsPath, "cgo_go_srcs", "", "The directory to emit cgo-generated Go sources for nogo consumption to")
 	fs.StringVar(&testFilter, "testfilter", "off", "Controls test package filtering")
@@ -131,6 +133,7 @@ func compilePkg(args []string) error {
 		packageListPath,
 		outLinkobjPath,
 		outInterfacePath,
+		outImportsPath,
 		cgoExportHPath,
 		cgoGoSrcsPath,
 		coverFormat,
@@ -163,6 +166,7 @@ func compileArchive(
 	packageListPath string,
 	outLinkObj string,
 	outInterfacePath string,
+	outImportsPath string,
 	cgoExportHPath string,
 	cgoGoSrcsForNogoPath string,
 	coverFormat string,
@@ -382,8 +386,12 @@ func compileArchive(
 		gcFlags = append(gcFlags, "-trimpath="+trimPath)
 	}
 
-	importcfgPath, err := checkImportsAndBuildCfg(goenv, importPath, srcs, deps, packageListPath, recompileInternalDeps, compilingWithCgo, coverMode, workDir)
+	importcfgPath, imports, err := checkImportsAndBuildCfg(goenv, importPath, srcs, deps, packageListPath, recompileInternalDeps, compilingWithCgo, coverMode, workDir)
 	if err != nil {
+		return err
+	}
+
+	if err := writeImports(outImportsPath, imports); err != nil {
 		return err
 	}
 
@@ -487,12 +495,12 @@ func compileArchive(
 	return nil
 }
 
-func checkImportsAndBuildCfg(goenv *env, importPath string, srcs archiveSrcs, deps []archive, packageListPath string, recompileInternalDeps []string, compilingWithCgo bool, coverMode string, workDir string) (string, error) {
+func checkImportsAndBuildCfg(goenv *env, importPath string, srcs archiveSrcs, deps []archive, packageListPath string, recompileInternalDeps []string, compilingWithCgo bool, coverMode string, workDir string) (string, map[string]*archive, error) {
 	// Check that the filtered sources don't import anything outside of
 	// the standard library and the direct dependencies.
 	imports, err := checkImports(srcs.goSrcs, deps, packageListPath, importPath, recompileInternalDeps)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
 	if compilingWithCgo {
 		// cgo generated code imports some extra packages.
@@ -513,7 +521,7 @@ func checkImportsAndBuildCfg(goenv *env, importPath string, srcs archiveSrcs, de
 			}
 		}
 		if coverdata == nil {
-			return "", errors.New("coverage requested but coverdata dependency not provided")
+			return "", nil, errors.New("coverage requested but coverdata dependency not provided")
 		}
 		imports[coverdataPath] = coverdata
 		imports["runtime/coverage"] = nil
@@ -522,9 +530,29 @@ func checkImportsAndBuildCfg(goenv *env, importPath string, srcs archiveSrcs, de
 	// Build an importcfg file for the compiler.
 	importcfgPath, err := buildImportcfgFileForCompile(imports, goenv.installSuffix, workDir)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
-	return importcfgPath, nil
+	return importcfgPath, imports, nil
+}
+
+func writeImports(path string, imports map[string]*archive) error {
+	packagePaths := make([]string, 0, len(imports))
+	for _, arc := range imports {
+		if arc != nil && arc.packagePath != "" {
+			packagePaths = append(packagePaths, arc.packagePath)
+		}
+	}
+	sort.Strings(packagePaths)
+
+	var buf bytes.Buffer
+	for i, packagePath := range packagePaths {
+		if i > 0 && packagePath == packagePaths[i-1] {
+			continue
+		}
+		buf.WriteString(packagePath)
+		buf.WriteByte('\n')
+	}
+	return os.WriteFile(path, buf.Bytes(), 0o666)
 }
 
 func compileGo(goenv *env, srcs []string, packagePath, importcfgPath, embedcfgPath, asmHdrPath, symabisPath string, gcFlags []string, pgoprofile, outLinkobjPath, outInterfacePath, coverageCfg string) error {

--- a/go/tools/builders/importcfg.go
+++ b/go/tools/builders/importcfg.go
@@ -27,8 +27,8 @@ import (
 )
 
 type archive struct {
-	label, importPath, packagePath, file string
-	importPathAliases                    []string
+	importPath, packagePath, file string
+	importPathAliases             []string
 }
 
 // checkImports verifies that each import in files refers to a

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -40,6 +40,7 @@ func link(args []string) error {
 	stamps := multiFlag{}
 	xdefs := multiFlag{}
 	packageMetadataFiles := multiFlag{}
+	importsFiles := multiFlag{}
 	archives := archiveMultiFlag{}
 	flags := flag.NewFlagSet("link", flag.ExitOnError)
 	goenv := envFlags(flags)
@@ -59,7 +60,8 @@ func link(args []string) error {
 	packagePath := flags.String("p", "", "Package path of the main archive.")
 	outFile := flags.String("o", "", "Path to output file.")
 	flags.Var(&archives, "arc", "Label, package path, and file name of a dependency, separated by '='")
-	flags.Var(&packageMetadataFiles, "package_metadata", "Path to a package_metadata JSON file (repeated).")
+	flags.Var(&packageMetadataFiles, "package_metadata", "Package path and path of a package_metadata JSON file, separated by '=' (repeated).")
+	flags.Var(&importsFiles, "imports", "Package path and path of an imports manifest, separated by '=' (repeated).")
 	packageList := flags.String("package_list", "", "The file containing the list of standard library packages")
 	buildmode := flags.String("buildmode", "", "Build mode used.")
 	flags.Var(&xdefs, "X", "A string variable to replace in the linked binary (repeated).")
@@ -111,7 +113,7 @@ func link(args []string) error {
 	// Build an importcfg file.
 	modinfo := ""
 	if shouldEmitBuildInfo(*buildmode) {
-		modules, err := modulesFromPackageMetadataFiles(packageMetadataFiles)
+		modules, err := reachableModules(*packagePath, packageMetadataFiles, importsFiles)
 		if err != nil {
 			return err
 		}

--- a/go/tools/builders/link.go
+++ b/go/tools/builders/link.go
@@ -54,6 +54,7 @@ func link(args []string) error {
 	// BuildInfo.Main as golang.org/x/tools@v0.34.0. The package and module paths
 	// differ when the executable package is below the module root.
 	mainModuleMetadata := flags.String("main_module_metadata", "", "Path to the main module's package_metadata JSON file.")
+	mainImportsPath := flags.String("main_imports", "", "Path to the main archive's own imports manifest.")
 	race := flags.Bool("race", false, "Whether race instrumentation is enabled.")
 	msan := flags.Bool("msan", false, "Whether memory sanitizer instrumentation is enabled.")
 	cover := flags.Bool("cover", false, "Whether coverage instrumentation is enabled.")
@@ -113,7 +114,7 @@ func link(args []string) error {
 	// Build an importcfg file.
 	modinfo := ""
 	if shouldEmitBuildInfo(*buildmode) {
-		modules, err := reachableModules(*packagePath, packageMetadataFiles, importsFiles)
+		modules, err := reachableModules(*mainImportsPath, packageMetadataFiles, importsFiles)
 		if err != nil {
 			return err
 		}

--- a/go/tools/builders/nogo.go
+++ b/go/tools/builders/nogo.go
@@ -81,7 +81,7 @@ func nogo(args []string) error {
 	defer cleanup()
 
 	compilingWithCgo := os.Getenv("CGO_ENABLED") == "1" && haveCgo
-	importcfgPath, err := checkImportsAndBuildCfg(goenv, importPath, srcs, deps, packageListPath, recompileInternalDeps, compilingWithCgo, coverMode, workDir)
+	importcfgPath, _, err := checkImportsAndBuildCfg(goenv, importPath, srcs, deps, packageListPath, recompileInternalDeps, compilingWithCgo, coverMode, workDir)
 	if err != nil {
 		return err
 	}

--- a/tests/core/go_binary/buildinfo_test.go
+++ b/tests/core/go_binary/buildinfo_test.go
@@ -65,6 +65,48 @@ go_test(
     deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
 )
 
+package_metadata(
+    name = "unused_lib_metadata",
+    purl = "pkg:golang/example.com/unused@v1.0.0",
+)
+
+go_library(
+    name = "unused_lib",
+    srcs = ["stdlib_only.go"],
+    importpath = "example.com/unused",
+    applicable_licenses = [":unused_lib_metadata"],
+)
+
+go_library(
+    name = "embedded_lib",
+    srcs = ["with_dep.go"],
+    importpath = "example.com/main/cmd/embedded_lib",
+    deps = ["@com_github_google_go_cmp//cmp:go_default_library"],
+)
+
+# Depends on embedded_lib the normal (non-embed) way because _recompile_external_deps
+# bails out early unless its label is also reachable through a regular dependency edge.
+go_library(
+    name = "dep_on_embedded_lib",
+    srcs = ["stdlib_only.go"],
+    importpath = "example.com/dep_on_embedded_lib",
+    deps = [":embedded_lib"],
+)
+
+# Regression test for the stub GoArchive branch reached above, which unused_lib
+# takes since it doesn't depend on embedded_lib.
+go_test(
+    name = "embedded_test",
+    srcs = ["embedded_test.go"],
+    embed = [":embedded_lib"],
+    applicable_licenses = [":main_package_metadata"],
+    deps = [
+        "@com_github_google_go_cmp//cmp:go_default_library",
+        ":unused_lib",  # Declared but not imported.
+        ":dep_on_embedded_lib",
+    ],
+)
+
 go_binary(
     name = "stdlib_only",
     srcs = ["stdlib_only.go"],
@@ -208,6 +250,38 @@ func TestBuildInfoDeps(t *testing.T) {
     }
     if !foundCmp {
         t.Fatalf("missing github.com/google/go-cmp@v0.6.0 in %+v", info.Deps)
+    }
+}
+
+-- embedded_test.go --
+package main
+
+import (
+    "runtime/debug"
+    "testing"
+
+    "github.com/google/go-cmp/cmp"
+)
+
+func TestBuildInfoDepsEmbeddedLib(t *testing.T) {
+    _ = cmp.Equal("use cmp", "use cmp")
+
+    info, ok := debug.ReadBuildInfo()
+    if !ok {
+        t.Fatal("ReadBuildInfo returned ok=false")
+    }
+
+    foundCmp := false
+    for _, dep := range info.Deps {
+        if dep.Path == "example.com/unused" {
+            t.Fatalf("got unimported declared dependency example.com/unused in %+v", info.Deps)
+        }
+        if dep.Path == "github.com/google/go-cmp" {
+            foundCmp = true
+        }
+    }
+    if !foundCmp {
+        t.Fatalf("missing github.com/google/go-cmp in %+v", info.Deps)
     }
 }
 
@@ -494,7 +568,6 @@ func TestReadBuildInfoDeps(t *testing.T) {
 	}
 
 	foundCmp := false
-	foundUnusedDeclaredDep := false
 	for _, dep := range got.Deps {
 		if dep.Path == "github.com/google/go-cmp" && dep.Version == "v0.6.0" {
 			foundCmp = true
@@ -503,18 +576,12 @@ func TestReadBuildInfoDeps(t *testing.T) {
 				t.Fatalf("got go-cmp Sum %q; want %q", dep.Sum, wantSum)
 			}
 		}
-		if dep.Path == "example.com/versionless" && dep.Version == "(devel)" {
-			foundUnusedDeclaredDep = true
-			if dep.Sum != "" {
-				t.Fatalf("got versionless Sum %q; want empty", dep.Sum)
-			}
+		if dep.Path == "example.com/versionless" {
+			t.Fatalf("got unimported declared dependency example.com/versionless in %+v", got.Deps)
 		}
 	}
 	if !foundCmp {
 		t.Fatalf("missing github.com/google/go-cmp@v0.6.0 in %+v", got.Deps)
-	}
-	if !foundUnusedDeclaredDep {
-		t.Fatalf("missing unused declared dependency example.com/versionless@(devel) in %+v", got.Deps)
 	}
 	for _, dep := range got.Deps {
 		if dep.Path == "example.com/main" {
@@ -614,6 +681,12 @@ func TestGoTestBuildInfoDeps(t *testing.T) {
 
 func TestGoTestBuildInfoDepsWithCoverage(t *testing.T) {
 	if _, err := bazel_testing.BazelOutput("coverage", "//:with_dep_test"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGoTestBuildInfoDepsEmbeddedLib(t *testing.T) {
+	if _, err := bazel_testing.BazelOutput("test", "//:embedded_test"); err != nil {
 		t.Fatal(err)
 	}
 }

--- a/tests/core/go_binary/buildinfo_test.go
+++ b/tests/core/go_binary/buildinfo_test.go
@@ -130,6 +130,34 @@ go_binary(
     srcs = ["with_vendored_dep.go"],
     deps = ["//third_party/vendored:vendored"],
 )
+
+package_metadata(
+    name = "colliding_leaf_metadata",
+    purl = "pkg:golang/example.com/colliding_leaf@v1.0.0",
+)
+
+go_library(
+    name = "colliding_leaf",
+    srcs = ["colliding_leaf.go"],
+    importpath = "example.com/colliding_leaf",
+    applicable_licenses = [":colliding_leaf_metadata"],
+)
+
+go_library(
+    name = "colliding_middle",
+    srcs = ["colliding_middle.go"],
+    importpath = "example.com/colliding",
+    deps = [":colliding_leaf"],
+)
+
+# Regression test: importpath is cosmetic on a go_binary (a main package always
+# compiles as "main"), so it can collide with a dependency's real importpath.
+go_binary(
+    name = "with_colliding_importpath",
+    srcs = ["with_colliding_importpath.go"],
+    importpath = "example.com/colliding",
+    deps = [":colliding_middle"],
+)
 -- direct_link_binary.bzl --
 load("@io_bazel_rules_go//go:def.bzl", "go_context", "go_rule", "new_go_info")
 
@@ -378,6 +406,44 @@ type output struct {
 func main() {
     _ = vendored.Name()
 
+    info, ok := debug.ReadBuildInfo()
+    out := output{OK: ok}
+    if info != nil {
+        for _, module := range info.Deps {
+            out.Deps = append(out.Deps, dep{Path: module.Path, Version: module.Version})
+        }
+    }
+    _ = json.NewEncoder(os.Stdout).Encode(out)
+}
+
+-- colliding_leaf.go --
+package collidingleaf
+-- colliding_middle.go --
+package collidingmiddle
+
+import _ "example.com/colliding_leaf"
+-- with_colliding_importpath.go --
+package main
+
+import (
+    "encoding/json"
+    "os"
+    "runtime/debug"
+
+    _ "example.com/colliding"
+)
+
+type dep struct {
+    Path    string ` + "`json:\"path\"`" + `
+    Version string ` + "`json:\"version\"`" + `
+}
+
+type output struct {
+    OK   bool  ` + "`json:\"ok\"`" + `
+    Deps []dep ` + "`json:\"deps\"`" + `
+}
+
+func main() {
     info, ok := debug.ReadBuildInfo()
     out := output{OK: ok}
     if info != nil {
@@ -740,4 +806,26 @@ func TestReadBuildInfoVendoredDep(t *testing.T) {
 		}
 	}
 	t.Fatalf("missing example.com/vendored@v1.2.3 in %+v", got.Deps)
+}
+
+func TestReadBuildInfoCollidingImportpath(t *testing.T) {
+	stdout, err := bazel_testing.BazelOutput("run", "//:with_colliding_importpath")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var got withDepOutput
+	if err := json.Unmarshal(stdout, &got); err != nil {
+		t.Fatalf("unmarshal output %q: %v", stdout, err)
+	}
+	if !got.OK {
+		t.Fatalf("ReadBuildInfo returned ok=false: %+v", got)
+	}
+
+	for _, dep := range got.Deps {
+		if dep.Path == "example.com/colliding_leaf" && dep.Version == "v1.0.0" {
+			return
+		}
+	}
+	t.Fatalf("missing example.com/colliding_leaf@v1.0.0 in %+v", got.Deps)
 }


### PR DESCRIPTION
**What type of PR is this?**
Bug fix

**What does this PR do? Why is it needed?**
`runtime/debug.BuildInfo().Deps`, built by #4595 (thanks again!), walks the full declared Bazel `deps` graph instead of the packages actually imported.

This diverges from `cmd/go`'s own `(*Package).setBuildInfo` in `cmd/go/internal/load/pkg.go`, which walks only `p.Internal.Imports`.

The mismatch makes `debug.BuildInfo().Deps` over-report dependencies, producing false positives for `govulncheck` and SBOM/vulnerability scanners that trust it to mean packages actually linked into the binary.

Each compiled package now writes an `-imports` manifest listing the `packagePath`s its filtered sources actually import, the same set `checkImports` already computes for the compiler's `importcfg`.

`GoLink` walks this manifest graph by BFS from the main package and filters `package_metadata` down to the genuinely reachable set, instead of trusting the full declared closure.

Reachability is keyed by `packagePath` rather than Bazel label, since a single `go_test` rule compiles multiple archives, internal, external, and a synthetic `testmain`, that all share one label.

`packagePath` is unique per compiled package within a link, matching the identity the linker itself already relies on for deduplication via `depsSeen` in `buildImportcfgFileForLink`.

A `go_binary`'s own `packagePath` is purely cosmetic and not enforced to be unique, so it can collide with a dependency's real one.
The main archive's own imports are therefore passed directly via a new `-main_imports` flag instead of being looked up by that ambiguous key, and its entry is excluded from the general `-imports` list `GoLink` walks.
`TestReadBuildInfoCollidingImportpath` reproduces this collision.

`TestReadBuildInfoDeps` is updated to assert that a declared-but-unimported dependency no longer appears.

`TestGoTestBuildInfoDepsEmbeddedLib` and `TestBuildInfoDepsEmbeddedLib` are added to cover the stub `GoArchive` branch that `_recompile_external_deps` takes for a library that is embedded but not itself imported.

**Which issues(s) does this PR fix?**
Fixes #4708.

**Other notes for review**
`emit_link` derives the `-package_metadata` and `-imports` flags from `archive.transitive` plus `test_archives`, excluding the main archive's own entry from `-imports` since its `packagePath` can collide with a dependency's.

The link action's `File` inputs come from a dedicated, recursively-built `_buildinfo_link_inputs` field on `GoArchive`, not from `archive.transitive`, since `depset`s support lazy merging of same-typed `depset`s but not lazy transformation into a different element type, so there is no way to extract `_imports`/`_package_metadata` `File`s from `GoArchiveData` elements without an eager pass.

Excluding the main archive from `-imports` uses a `map_each` closure over `archive.data.file`, with `allow_closure = True`.
`_format_imports` compares `File` objects directly (`d.file == main_archive_file`) rather than their `.path` strings, since `Artifact.equals()` compares `execPath` and `root` directly and is unaffected by Bazel's path mapping, unlike a `.path` string, which is only remapped when read from inside a `map_each` callback.
