### PR TITLE
cgo: support `compilation_context.external_includes`

### DIFF
--- a/go/private/rules/cgo.bzl
+++ b/go/private/rules/cgo.bzl
@@ -128,6 +128,9 @@ def cgo_configure(go, srcs, cdeps, cppopts, copts, cxxopts, clinkopts):
             cc_system_includes = d[CcInfo].compilation_context.system_includes.to_list()
             for inc in cc_system_includes:
                 _include_unique(cppopts, "-isystem", inc, seen_system_includes)
+            if hasattr(d[CcInfo].compilation_context, "external_includes"):
+                for inc in d[CcInfo].compilation_context.external_includes.to_list():
+                    _include_unique(cppopts, "-isystem", inc, seen_system_includes)
             for lib in cc_libs:
                 # If both static and dynamic variants are available, Bazel will only give
                 # us the static variant. We'll get one file for each transitive dependency,

--- a/tests/core/cgo/external_includes_test.go
+++ b/tests/core/cgo/external_includes_test.go
@@ -29,12 +29,26 @@ bazel_dep(name = "rules_go", repo_name = "io_bazel_rules_go")
 bazel_dep(name = "rules_cc", version = "0.1.5")
 -- other_repo/cc/BUILD.bazel --
 load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_binary(
     name = "main",
     srcs = ["main.c"],
     deps = ["//cgo"],
 )
+
+cc_library(
+    name = "lib",
+    hdrs = ["sub/lib.h"],
+    srcs = ["sub/lib.c"],
+    includes = ["sub"],
+    visibility = ["//visibility:public"],
+)
+-- other_repo/cc/sub/lib.h --
+#pragma once
+int lib_func(void);
+-- other_repo/cc/sub/lib.c --
+int lib_func(void) { return 42; }
 -- other_repo/cc/main.c --
 #include "cgo/cgo.h"
 
@@ -66,6 +80,25 @@ import "C"
 func HelloCgo() {}
 
 func main() {}
+-- BUILD.bazel --
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "cgo_ext",
+    srcs = ["cgo_ext.go"],
+    cgo = True,
+    cdeps = ["@other_repo//cc:lib"],
+    importpath = "example.com/rules_go/cgo_ext",
+)
+-- cgo_ext.go --
+package cgo_ext
+
+// #include "lib.h"
+import "C"
+
+func Answer() int {
+    return int(C.lib_func())
+}
 `,
 		ModuleFileSuffix: `
 bazel_dep(name = "other_repo", version = "0.0.0")
@@ -85,6 +118,11 @@ func TestExternalIncludes(t *testing.T) {
 	})
 	t.Run("experimental_sibling_repository_layout", func(t *testing.T) {
 		if err := bazel_testing.RunBazel("build", "--experimental_sibling_repository_layout", "@other_repo//cc:main"); err != nil {
+			t.Fatalf("Did not expect error:\n%+v", err)
+		}
+	})
+	t.Run("external_include_paths", func(t *testing.T) {
+		if err := bazel_testing.RunBazel("build", "--features=external_include_paths", "//:cgo_ext"); err != nil {
 			t.Fatalf("Did not expect error:\n%+v", err)
 		}
 	})


### PR DESCRIPTION
**What type of PR is this?**

Bug fix

**What does this PR do? Why is it needed?**

When `--features=external_include_paths` is enabled in Bazel, external repository include directories are collected into
`CcInfo.compilation_context.external_includes` rather than standard includes.

Previously, `cgo.bzl` only traversed `defines`, `includes`, `quote_includes`, and `system_includes`, omitting `external_includes`. Consequently, cgo targets depending on C/C++ targets in external repositories failed to resolve headers during cgo compilation.

This change:
1. Forwards `compilation_context.external_includes` as `-isystem` in `cgo.bzl` when present.
2. Adds a test case in `tests/core/cgo:external_includes_test` that builds a cgo target depending on an external repository `cc_library` with `--features=external_include_paths`.

**Which issues(s) does this PR fix?**

None filed.