### PR TITLE
Detect the host platform on DragonFly

### DIFF
--- a/go/private/sdk.bzl
+++ b/go/private/sdk.bzl
@@ -480,6 +480,8 @@ def detect_host_platform(ctx):
     goos = ctx.os.name
     if goos == "mac os x":
         goos = "darwin"
+    elif goos == "dragonflybsd":
+        goos = "dragonfly"
     elif goos.startswith("windows"):
         goos = "windows"
 


### PR DESCRIPTION
detect_host_platform takes ctx.os.name as GOOS and maps the two cases
where the JVM spells the name differently, "mac os x" and "windows ...".
DragonFly is a third: the JVM reports "dragonflybsd" where Go says
"dragonfly". Go ships dragonfly-amd64 in every release, and platforms.bzl
already lists the pair.

On DragonFly 6.4 today a go_binary stops at

    no such target '@@rules_go+//go/toolchain:dragonflybsd'

With this change the SDK and the toolchain get their right names.
Toolchain resolution on a DragonFly host still needs
@platforms//os:dragonfly, which bazelbuild/platforms#143 adds; once that
is in the platforms release rules_go depends on, one line in
BAZEL_GOOS_CONSTRAINTS maps "dragonfly" to it. I have kept that line out
of this change, since the label does not exist yet. With both applied
locally, a go_binary builds and runs on DragonFly 6.4 (Bazel 10.0.0-pre,
Go 1.25.1: "hello from dragonfly amd64").
